### PR TITLE
Clean stray markdown markers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,4 +21,3 @@ training:
 logging:
   level: "INFO"
   log_file: "logs/poker_ai.log" # Changed to relative path for consistency
-```

--- a/readme.md
+++ b/readme.md
@@ -21,3 +21,9 @@ This project implements a Texas Hold'em AI using Counterfactual Regret Minimizat
 1. **Install dependencies**:
    ```bash
    pip install -r requirements.txt
+   ```
+
+2. **Run training**:
+   ```bash
+   python run_training.py
+   ```

--- a/run_training.py
+++ b/run_training.py
@@ -125,4 +125,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-```

--- a/self_play/self_play.py
+++ b/self_play/self_play.py
@@ -430,4 +430,3 @@ if __name__ == '__main__':
         print("No training data was collected.")
 
     print("\nSelfPlay with counterfactual logic and trainer integration test finished.")
-```

--- a/tests/test_model_forward_pass.py
+++ b/tests/test_model_forward_pass.py
@@ -94,5 +94,3 @@ if __name__ == '__main__':
         print(f"\nAn unexpected error occurred during testing: {e}")
         import traceback
         traceback.print_exc()
-
-```

--- a/trainers/ai_cfr_trainer.py
+++ b/trainers/ai_cfr_trainer.py
@@ -144,5 +144,3 @@ class AICFRTrainer:
             logging.warning("Cumulative strategy is all zeros. Returning uniform strategy.")
             return torch.ones(self.num_actions) / self.num_actions
         return self.cumulative_strategy / sum_cumulative_strategy
-
-```

--- a/utils/state_representation.py
+++ b/utils/state_representation.py
@@ -368,36 +368,3 @@ if __name__ == '__main__':
         _get_numeric_player_id("player_x", player_order_mock)
     except ValueError as e:
         print(f"Correctly caught error for 'player_x': {e}")
-
-```The file `utils/state_representation.py` has been created and updated.
-
-Key changes and features implemented:
-1.  **Mock Objects**: `MockPlayer` and `MockGameState` are defined for standalone testing. `MockGameState` now includes `player_order` and `players_map` for clarity.
-2.  **Constants**: `RANK_TO_NUM`, `SUIT_TO_NUM`, `ACTION_TO_ID`, `ROUND_TO_ID` are defined globally. Type indicators (`TYPE_ID_*`) and normalization constants (`NORM_AMOUNT`, `NORM_STACK_POT`) are also defined.
-3.  **`_encode_card(card_str)`**: Encodes card strings (e.g., 'Ah', 'Td') to a float (rank + suit/10). Handles case variations for card strings.
-4.  **`_get_numeric_player_id(player_id_str, all_player_ids_in_order)`**: Converts string player ID to its integer index based on the provided ordered list of all player IDs in the game. This ensures consistent numeric IDs.
-5.  **`prepare_transformer_input` Function**:
-    *   **Signature**: `(game_state, current_player_id, max_seq_len, d_raw_feature)`. The `players_list` argument was removed as player information can be sourced from `game_state`.
-    *   **`_create_feature` Helper**: A new internal helper `_create_feature(v1, v2, v3_or_type_id)` was defined to construct feature vectors of length `d_raw_feature`.
-        *   If `d_raw_feature == 3`, it returns `[v1, v2, v3_or_type_id]`.
-        *   If `d_raw_feature > 3`, it pads with zeros: `[v1, v2, v3_or_type_id, 0, ..., 0]`.
-        *   If `d_raw_feature < 3`, it truncates.
-    *   **Card Encoding**: Player's hand and community cards are encoded as `[encoded_value, 0.0, TYPE_ID_CARD]`. `TYPE_ID_CARD` is currently 0.0.
-    *   **Betting History Encoding**: Actions are encoded as `[numeric_player_id, numeric_action_id, normalized_amount]`. `numeric_player_id` is the index of the player. Amounts are normalized by `NORM_AMOUNT`.
-    *   **Other Game State Features**:
-        *   Pot: `[normalized_pot, 0.0, TYPE_ID_POT]`
-        *   Current Bet Faced: `[normalized_bet_faced, 0.0, TYPE_ID_CURRENT_BET]`. This is calculated as `max(0, game_state.current_bet - current_player_obj.current_bet_in_round)`.
-        *   Player Stack: `[normalized_stack, 0.0, TYPE_ID_PLAYER_STACK]`
-        *   Round: `[round_id_numeric, 0.0, TYPE_ID_ROUND]`
-        *   Normalization for pot and stack uses `NORM_STACK_POT`.
-    *   **Padding/Truncation**: The sequence of feature vectors is padded with `[0.0] * d_raw_feature` or truncated to `max_seq_len`.
-    *   **Tensor Conversion**: The final sequence is converted to a `torch.Tensor` of `dtype=torch.float32`.
-6.  **`if __name__ == '__main__':` Block**:
-    *   Includes comprehensive test cases for different game scenarios (flop, pre-flop with blinds).
-    *   Demonstrates usage with `d_raw_feature` set to 3 (as per prompt examples), and also tests with smaller (1) and larger (5) values for `d_raw_feature`.
-    *   Prints shapes and selected token values for verification against expected outputs.
-    *   Includes standalone tests for helper functions `_encode_card` and `_get_numeric_player_id`.
-
-The implementation aligns with the requirements, providing a structured way to convert game state information into a numerical tensor suitable for a Transformer model. The feature construction strategy (especially for `d_raw_feature=3`) follows the pattern examples given in the prompt.
-
-This subtask should be complete.


### PR DESCRIPTION
## Summary
- remove leftover Markdown from `run_training.py`
- clean stray markers in `self_play/self_play.py`
- remove extraneous markers in `tests/test_model_forward_pass.py`
- fix markdown in `trainers/ai_cfr_trainer.py`
- strip outdated notes from `utils/state_representation.py`
- tidy up `config.yaml`
- close README code block and add training instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_683ab7debcac832aa215844c6661479a