### PR TITLE
Improve hand evaluation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,8 @@ This project implements a Texas Hold'em AI using Counterfactual Regret Minimizat
 - **ai_models**: Contains the neural network models (Transformer).
 - **trainers**: Includes the AI trainers, self-play scripts, and performance profiling tools.
 - **play**: Handles the human vs. AI gameplay and GUI.
-- **rules**: Defines the Texas Hold'em rules and game logic.
+- **rules**: Defines the Texas Hold'em rules and game logic. If the optional
+  `treys` library is installed, hand evaluation uses it for accurate ranking.
 - **tests**: Unit tests for all major components.
 - **scripts**: Main scripts for running training and simulations.
 - **self_play_data**: Directory for storing self-play results.

--- a/rules/texas_holdem_rules.py
+++ b/rules/texas_holdem_rules.py
@@ -1,5 +1,10 @@
 import random
 from itertools import combinations
+try:
+    from treys import Evaluator, Card
+except ImportError:  # Fall back to simple evaluation if treys isn't installed
+    Evaluator = None
+    Card = None
 
 class TexasHoldemRules:
     def __init__(self, num_players=2):
@@ -140,8 +145,50 @@ class TexasHoldemRules:
         return winner
 
     def evaluate_hand(self, cards):
-        # Simplified hand evaluation (to be replaced with full poker hand evaluation logic)
-        rank_values = {'2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9, '10': 10, 'J': 11, 'Q': 12, 'K': 13, 'A': 14}
+        """Evaluate the strength of a hand.
+
+        If the ``treys`` library is available, use it for a proper Texas
+        Hold'em hand evaluation. Otherwise fall back to a very simple
+        ranking based on card values.
+
+        Parameters
+        ----------
+        cards : list[tuple[str, str]]
+            List of ``(rank, suit)`` tuples. The first two items are assumed to
+            be the player's hole cards followed by community cards.
+
+        Returns
+        -------
+        int
+            A numeric strength where a lower value is a stronger hand when using
+            ``treys``. With the simplified evaluation a higher value means a
+            stronger hand.
+        """
+
+        if Evaluator is not None and Card is not None and len(cards) >= 2:
+            evaluator = Evaluator()
+            suit_map = {
+                'hearts': 'h',
+                'diamonds': 'd',
+                'clubs': 'c',
+                'spades': 's',
+            }
+
+            def to_treys(card_tuple: tuple[str, str]) -> str:
+                rank, suit = card_tuple
+                rank_map = {'10': 'T'}
+                rank = rank_map.get(rank, rank)
+                return f"{rank}{suit_map.get(suit, suit[0])}"
+
+            hole_cards = [Card.new(to_treys(c)) for c in cards[:2]]
+            board_cards = [Card.new(to_treys(c)) for c in cards[2:]]
+            return evaluator.evaluate(board_cards, hole_cards)
+
+        # Fallback simplified evaluation
+        rank_values = {
+            '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8,
+            '9': 9, '10': 10, 'J': 11, 'Q': 12, 'K': 13, 'A': 14,
+        }
         return sum(rank_values[rank] for rank, suit in cards)
 
     def award_pot(self, winner):


### PR DESCRIPTION
## Summary
- integrate optional treys based evaluation in `TexasHoldemRules.evaluate_hand`
- document treys usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy, torch, treys)*

------
https://chatgpt.com/codex/tasks/task_b_683c725c630c832a9aa9d357f97eb050