### PR TITLE
Fix curriculum interval logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 *.pyc
 **/__pycache__/
 .pytest_cache/
+logs/
+models/

--- a/run_training.py
+++ b/run_training.py
@@ -109,10 +109,12 @@ def main():
             traceback.print_exc()
 
 
-        if curriculum_stages and hand_num % (num_training_hands // len(curriculum_stages)) == 0:
-            stage_index = min(stage_index + 1, len(curriculum_stages) - 1)
-            game_config_for_selfplay.update(curriculum_stages[stage_index])
-            self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
+        if curriculum_stages:
+            stage_interval = max(1, num_training_hands // len(curriculum_stages))
+            if hand_num % stage_interval == 0:
+                stage_index = min(stage_index + 1, len(curriculum_stages) - 1)
+                game_config_for_selfplay.update(curriculum_stages[stage_index])
+                self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
 
         if hand_num % save_model_every_n_hands == 0:
             print(f"\n--- Saving model at hand {hand_num} ---")

--- a/trainers/ai_cfr_trainer.py
+++ b/trainers/ai_cfr_trainer.py
@@ -2,6 +2,7 @@ import torch
 import torch.optim as optim
 import logging
 import yaml
+import os
 from ai_models.transformer import TransformerAverageStrategy
 # Assuming rules.cfr is accessible from this path. Adjust if necessary.
 # e.g., if 'rules' is a top-level directory: from rules.cfr import ...
@@ -27,7 +28,11 @@ except FileNotFoundError:
 
 
 # Setup logging
-logging.basicConfig(filename=config['logging']['log_file'], level=logging.INFO, filemode='a')
+log_file_path = config['logging']['log_file']
+log_dir = os.path.dirname(log_file_path)
+if log_dir and not os.path.exists(log_dir):
+    os.makedirs(log_dir, exist_ok=True)
+logging.basicConfig(filename=log_file_path, level=logging.INFO, filemode='a')
 
 class AICFRTrainer:
     def __init__(self):


### PR DESCRIPTION
## Summary
- fix curriculum stage transition logic when training hand count is less than number of stages
- ignore models directory so saved weights aren't tracked

## Testing
- `pytest -q`
- `python run_training.py`

------
https://chatgpt.com/codex/tasks/task_b_684191ddf5cc832aa84dd1da39bb1df2