### PR TITLE
Add CLI to training script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,18 @@ This project implements a Texas Hold'em AI using Counterfactual Regret Minimizat
    python run_training.py
    ```
 
+### Training CLI Options
+
+`run_training.py` exposes several command-line flags. Use `-h` to see all options.
+
+Example:
+
+```bash
+python run_training.py --num-hands 500 --algorithm deep_cfr --save-model-every 50
+```
+
+During training each hand uses a random number of players (between 2 and 10).
+
 3. **Run tests**:
    ```bash
    pytest -q

--- a/run_training.py
+++ b/run_training.py
@@ -1,5 +1,7 @@
 import yaml
 import os # For path manipulation if needed, e.g. for robust config loading
+import argparse
+import random
 
 # Assuming the script is run from the project root,
 # and trainers, self_play, etc., are packages in that root.
@@ -9,7 +11,7 @@ from typing import List, Dict
 
 # Configuration Loading
 # Robustly locate config.yaml assuming it's in the project root
-CONFIG_FILE_PATH = "config.yaml" 
+CONFIG_FILE_PATH = "config.yaml"
 # If script is not in root, adjust path:
 # CONFIG_FILE_PATH = os.path.join(os.path.dirname(__file__), "config.yaml") # If config is with script
 # Or an absolute path, or environment variable. For now, assume it's in CWD.
@@ -31,11 +33,64 @@ def load_configuration(config_path: str) -> dict:
         return {}
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the training script."""
+    parser = argparse.ArgumentParser(description="Run Poker AI training session")
+    parser.add_argument(
+        "--num-hands",
+        type=int,
+        help="Number of hands to simulate (overrides config)"
+    )
+    parser.add_argument(
+        "--save-model-every",
+        type=int,
+        help="Save model every N hands"
+    )
+    parser.add_argument(
+        "--algorithm",
+        default="ai_cfr",
+        choices=["ai_cfr", "deep_cfr", "single_network"],
+        help="Training algorithm to use"
+    )
+    parser.add_argument(
+        "--config",
+        default=CONFIG_FILE_PATH,
+        help="Path to configuration YAML file"
+    )
+    return parser.parse_args()
+
+
+def initialize_trainer(algorithm: str, config: dict):
+    """Return a trainer instance based on selected algorithm."""
+    if algorithm == "ai_cfr":
+        return AICFRTrainer()
+    elif algorithm == "deep_cfr":
+        from trainers.deep_cfr_trainer import DeepCFRTrainer
+        model_cfg = config.get("model", {})
+        d_raw = model_cfg.get("d_raw_feature", 3)
+        hidden = model_cfg.get("hidden_dim", 128)
+        num_actions = model_cfg.get("num_actions", 10)
+        lr = model_cfg.get("learning_rate", 1e-3)
+        return DeepCFRTrainer(d_raw, hidden, num_actions, learning_rate=lr)
+    elif algorithm == "single_network":
+        from trainers.single_network_cfr_trainer import SingleNetworkCFRTrainer
+        model_cfg = config.get("model", {})
+        d_raw = model_cfg.get("d_raw_feature", 3)
+        hidden = model_cfg.get("hidden_dim", 128)
+        num_actions = model_cfg.get("num_actions", 10)
+        lr = model_cfg.get("learning_rate", 1e-3)
+        return SingleNetworkCFRTrainer(d_raw, hidden, num_actions, lr)
+    else:
+        raise ValueError(f"Unknown algorithm: {algorithm}")
+
+
 def main():
     print("--- Starting Poker AI Training Session ---")
 
+    args = parse_args()
+
     # Load configuration
-    config = load_configuration(CONFIG_FILE_PATH)
+    config = load_configuration(args.config)
 
     # Extract configurations with defaults
     # model_config is implicitly used by AICFRTrainer via its own global config load.
@@ -45,9 +100,13 @@ def main():
     training_params = config.get('training', {})
     curriculum_stages: List[Dict] = config.get('curriculum', {}).get('stages', [])
 
-    # Training Parameters
-    num_training_hands = training_params.get('num_training_hands', 1000)
-    save_model_every_n_hands = training_params.get('save_model_every_n_hands', 100)
+    # Training Parameters with CLI overrides
+    num_training_hands = (
+        args.num_hands if args.num_hands is not None else training_params.get('num_training_hands', 1000)
+    )
+    save_model_every_n_hands = (
+        args.save_model_every if args.save_model_every is not None else training_params.get('save_model_every_n_hands', 100)
+    )
     
     # Game Engine Parameters for SelfPlay
     num_players = game_engine_config.get('num_players', 2)
@@ -74,28 +133,26 @@ def main():
     }
 
     try:
-        cfr_trainer = AICFRTrainer() # Loads its own model config from 'config.yaml'
-        print("AICFRTrainer initialized.")
+        cfr_trainer = initialize_trainer(args.algorithm, config)
+        print(f"{args.algorithm} trainer initialized.")
     except Exception as e:
-        print(f"Error initializing AICFRTrainer: {e}")
+        print(f"Error initializing trainer: {e}")
         print("Please ensure 'config.yaml' is present and correctly formatted, especially the 'model' section.")
-        return # Exit if trainer fails to initialize
+        return  # Exit if trainer fails to initialize
 
-    try:
-        self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
-        print("SelfPlay environment initialized.")
-    except Exception as e:
-        print(f"Error initializing SelfPlay environment: {e}")
-        return # Exit if self-play fails
+
 
     # Training Loop
     print("\n--- Starting Training Loop ---")
     stage_index = 0
     if curriculum_stages:
         game_config_for_selfplay.update(curriculum_stages[stage_index])
-        self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
+
     for hand_num in range(1, num_training_hands + 1):
-        print(f"\n--- Training Hand {hand_num}/{num_training_hands} ---")
+        num_players_this_round = random.randint(2, 10)
+        game_config_for_selfplay['num_players'] = num_players_this_round
+        self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
+        print(f"\n--- Training Hand {hand_num}/{num_training_hands} (Players: {num_players_this_round}) ---")
         try:
             # The play_hand_for_training method now collects data and calls cfr_trainer.train internally
             _ = self_play_env.play_hand_for_training()
@@ -114,7 +171,6 @@ def main():
             if hand_num % stage_interval == 0:
                 stage_index = min(stage_index + 1, len(curriculum_stages) - 1)
                 game_config_for_selfplay.update(curriculum_stages[stage_index])
-                self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
 
         if hand_num % save_model_every_n_hands == 0:
             print(f"\n--- Saving model at hand {hand_num} ---")


### PR DESCRIPTION
## Summary
- add argparse CLI options to `run_training.py`
- support algorithm selection and player randomization per hand
- update README with new training usage
- improve trainer initialization error message

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `timeout 10s python run_training.py --num-hands 1 --save-model-every 1`

------
https://chatgpt.com/codex/tasks/task_b_68429fe03b3c832ab0738ff992319a49