### PR TITLE
Fix training initialization and state updates

### DIFF
--- a/ai_models/transformer.py
+++ b/ai_models/transformer.py
@@ -12,6 +12,8 @@ class TransformerAverageStrategy(nn.Module):
             num_decoder_layers=num_layers  # Or consider just using TransformerEncoder
         )
         self.fc = nn.Linear(hidden_dim, num_actions)
+        # Store number of actions for convenience
+        self.num_actions = num_actions
 
     def forward(self, x, src_mask=None):
         # x shape: (batch_size, seq_len, input_feature_dim)

--- a/game_engine/game_state.py
+++ b/game_engine/game_state.py
@@ -7,9 +7,26 @@ class GameState:
         self.current_bet = 0
         self.current_round = 'pre-flop'
         self.players = []
+        # Keep track of player ordering for feature encoding
+        self.player_order = []
+        # Some utilities expect `betting_round` attribute
+        self.betting_round = self.current_round
 
     def set_players(self, players):
         self.players = players
+        # Assume players is a list of objects with a player_id attribute
+        try:
+            self.player_order = [str(p.player_id) for p in players]
+        except AttributeError:
+            # Fallback if players are provided as IDs or lacking attribute
+            self.player_order = [str(p) for p in players]
+
+    def get_player(self, player_id):
+        """Return player object by id if available."""
+        for p in self.players:
+            if getattr(p, 'player_id', None) == player_id or str(p) == str(player_id):
+                return p
+        return None
 
     def set_player_hand(self, player_id, hand):
         self.player_hands[player_id] = hand

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,18 @@ This project implements a Texas Hold'em AI using Counterfactual Regret Minimizat
    python run_training.py
    ```
 
+### Training CLI Options
+
+`run_training.py` exposes several command-line flags. Use `-h` to see all options.
+
+Example:
+
+```bash
+python run_training.py --num-hands 500 --algorithm deep_cfr --save-model-every 50
+```
+
+During training each hand uses a random number of players (between 2 and 10).
+
 3. **Run tests**:
    ```bash
    pytest -q

--- a/run_training.py
+++ b/run_training.py
@@ -1,5 +1,7 @@
 import yaml
 import os # For path manipulation if needed, e.g. for robust config loading
+import argparse
+import random
 
 # Assuming the script is run from the project root,
 # and trainers, self_play, etc., are packages in that root.
@@ -9,7 +11,7 @@ from typing import List, Dict
 
 # Configuration Loading
 # Robustly locate config.yaml assuming it's in the project root
-CONFIG_FILE_PATH = "config.yaml" 
+CONFIG_FILE_PATH = "config.yaml"
 # If script is not in root, adjust path:
 # CONFIG_FILE_PATH = os.path.join(os.path.dirname(__file__), "config.yaml") # If config is with script
 # Or an absolute path, or environment variable. For now, assume it's in CWD.
@@ -31,11 +33,64 @@ def load_configuration(config_path: str) -> dict:
         return {}
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the training script."""
+    parser = argparse.ArgumentParser(description="Run Poker AI training session")
+    parser.add_argument(
+        "--num-hands",
+        type=int,
+        help="Number of hands to simulate (overrides config)"
+    )
+    parser.add_argument(
+        "--save-model-every",
+        type=int,
+        help="Save model every N hands"
+    )
+    parser.add_argument(
+        "--algorithm",
+        default="ai_cfr",
+        choices=["ai_cfr", "deep_cfr", "single_network"],
+        help="Training algorithm to use"
+    )
+    parser.add_argument(
+        "--config",
+        default=CONFIG_FILE_PATH,
+        help="Path to configuration YAML file"
+    )
+    return parser.parse_args()
+
+
+def initialize_trainer(algorithm: str, config: dict):
+    """Return a trainer instance based on selected algorithm."""
+    if algorithm == "ai_cfr":
+        return AICFRTrainer()
+    elif algorithm == "deep_cfr":
+        from trainers.deep_cfr_trainer import DeepCFRTrainer
+        model_cfg = config.get("model", {})
+        d_raw = model_cfg.get("d_raw_feature", 3)
+        hidden = model_cfg.get("hidden_dim", 128)
+        num_actions = model_cfg.get("num_actions", 10)
+        lr = model_cfg.get("learning_rate", 1e-3)
+        return DeepCFRTrainer(d_raw, hidden, num_actions, learning_rate=lr)
+    elif algorithm == "single_network":
+        from trainers.single_network_cfr_trainer import SingleNetworkCFRTrainer
+        model_cfg = config.get("model", {})
+        d_raw = model_cfg.get("d_raw_feature", 3)
+        hidden = model_cfg.get("hidden_dim", 128)
+        num_actions = model_cfg.get("num_actions", 10)
+        lr = model_cfg.get("learning_rate", 1e-3)
+        return SingleNetworkCFRTrainer(d_raw, hidden, num_actions, lr)
+    else:
+        raise ValueError(f"Unknown algorithm: {algorithm}")
+
+
 def main():
     print("--- Starting Poker AI Training Session ---")
 
+    args = parse_args()
+
     # Load configuration
-    config = load_configuration(CONFIG_FILE_PATH)
+    config = load_configuration(args.config)
 
     # Extract configurations with defaults
     # model_config is implicitly used by AICFRTrainer via its own global config load.
@@ -45,9 +100,13 @@ def main():
     training_params = config.get('training', {})
     curriculum_stages: List[Dict] = config.get('curriculum', {}).get('stages', [])
 
-    # Training Parameters
-    num_training_hands = training_params.get('num_training_hands', 1000)
-    save_model_every_n_hands = training_params.get('save_model_every_n_hands', 100)
+    # Training Parameters with CLI overrides
+    num_training_hands = (
+        args.num_hands if args.num_hands is not None else training_params.get('num_training_hands', 1000)
+    )
+    save_model_every_n_hands = (
+        args.save_model_every if args.save_model_every is not None else training_params.get('save_model_every_n_hands', 100)
+    )
     
     # Game Engine Parameters for SelfPlay
     num_players = game_engine_config.get('num_players', 2)
@@ -74,28 +133,26 @@ def main():
     }
 
     try:
-        cfr_trainer = AICFRTrainer() # Loads its own model config from 'config.yaml'
-        print("AICFRTrainer initialized.")
+        cfr_trainer = initialize_trainer(args.algorithm, config)
+        print(f"{args.algorithm} trainer initialized.")
     except Exception as e:
-        print(f"Error initializing AICFRTrainer: {e}")
+        print(f"Error initializing trainer: {e}")
         print("Please ensure 'config.yaml' is present and correctly formatted, especially the 'model' section.")
-        return # Exit if trainer fails to initialize
+        return  # Exit if trainer fails to initialize
 
-    try:
-        self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
-        print("SelfPlay environment initialized.")
-    except Exception as e:
-        print(f"Error initializing SelfPlay environment: {e}")
-        return # Exit if self-play fails
+
 
     # Training Loop
     print("\n--- Starting Training Loop ---")
     stage_index = 0
     if curriculum_stages:
         game_config_for_selfplay.update(curriculum_stages[stage_index])
-        self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
+
     for hand_num in range(1, num_training_hands + 1):
-        print(f"\n--- Training Hand {hand_num}/{num_training_hands} ---")
+        num_players_this_round = random.randint(2, 10)
+        game_config_for_selfplay['num_players'] = num_players_this_round
+        self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
+        print(f"\n--- Training Hand {hand_num}/{num_training_hands} (Players: {num_players_this_round}) ---")
         try:
             # The play_hand_for_training method now collects data and calls cfr_trainer.train internally
             _ = self_play_env.play_hand_for_training()
@@ -114,7 +171,6 @@ def main():
             if hand_num % stage_interval == 0:
                 stage_index = min(stage_index + 1, len(curriculum_stages) - 1)
                 game_config_for_selfplay.update(curriculum_stages[stage_index])
-                self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
 
         if hand_num % save_model_every_n_hands == 0:
             print(f"\n--- Saving model at hand {hand_num} ---")

--- a/self_play/self_play.py
+++ b/self_play/self_play.py
@@ -84,12 +84,15 @@ class SelfPlay:
         elif num_community_cards == 3: ai_gs.current_round = 'flop'
         elif num_community_cards == 4: ai_gs.current_round = 'turn'
         elif num_community_cards == 5: ai_gs.current_round = 'river'
-        else: ai_gs.current_round = 'unknown' 
+        else: ai_gs.current_round = 'unknown'
+        ai_gs.betting_round = ai_gs.current_round
         ai_gs_players_list: List[AI_Player] = []
         for i in range(engine_rules.num_players):
             player_id_str = str(i)
             stack_size = engine_rules.player_chips[i]
             ai_player_obj = AI_Player(player_id=player_id_str, stack_size=stack_size)
+            # Some utilities expect attribute `stack` for stack size
+            ai_player_obj.stack = stack_size
             if i == self.ai_player_idx:
                 if engine_rules.hands and i < len(engine_rules.hands):
                      ai_player_obj.hand = list(engine_rules.hands[i])
@@ -97,6 +100,7 @@ class SelfPlay:
             ai_player_obj.current_bet_in_round = engine_rules.bets[i]
             ai_gs_players_list.append(ai_player_obj)
         ai_gs.players = ai_gs_players_list
+        ai_gs.player_order = [p.player_id for p in ai_gs_players_list]
         return ai_gs
 
     def _get_opponent_action(self, engine_rules_obj: TexasHoldemRules, player_index: int) -> Tuple[str, int | None]:
@@ -224,6 +228,7 @@ class SelfPlay:
                     continue 
                 action_str, amount_val = self._get_opponent_action(sim_engine.rules, current_player_sub_sim)
                 sim_engine.process_action(current_player_sub_sim, action_str, amount_val)
+                sim_engine.rules.advance_turn()
                 sim_engine.rules.actions_this_round += 1
                 num_active_in_sim_rules = sum(1 for active_p in sim_engine.rules.active_players if active_p)
                 if num_active_in_sim_rules < 2: sim_engine.end_game_early = True
@@ -292,8 +297,12 @@ class SelfPlay:
                     model_config = self.cfr_trainer.config.get('model', {})
                     max_seq_len = model_config.get('max_seq_len', 20) 
                     d_raw_feature = model_config.get('d_raw_feature', 3)
-                    state_tensor = prepare_transformer_input(current_ai_view_gs, str(self.ai_player_idx), 
-                                                             current_ai_view_gs.players, max_seq_len, d_raw_feature)
+                    state_tensor = prepare_transformer_input(
+                        current_ai_view_gs,
+                        str(self.ai_player_idx),
+                        max_seq_len,
+                        d_raw_feature,
+                    )
                     strategy_probs_tensor = self.cfr_trainer.model(state_tensor.unsqueeze(0)).squeeze(0)
                     if not torch.all(strategy_probs_tensor >= 0):
                         print(f"Warning: strategy_probs_tensor has negative values: {strategy_probs_tensor}. Using uniform.")
@@ -360,12 +369,15 @@ class SelfPlay:
                     action_to_engine_str, amount_for_engine = action_tuple
                 
                 self.game_engine.process_action(current_player_engine_idx, action_to_engine_str, amount_for_engine)
+                self.game_engine.rules.advance_turn()
                 main_ai_gs.record_action(str(current_player_engine_idx), action_tuple)
-                self.game_engine.rules.actions_this_round += 1 
+                self.game_engine.rules.actions_this_round += 1
                 num_active_after_action = sum(1 for active_p in self.game_engine.rules.active_players if active_p)
-                if num_active_after_action < 2: self.game_engine.end_game_early = True
+                if num_active_after_action < 2:
+                    self.game_engine.end_game_early = True
                 main_ai_gs = self._populate_ai_gamestate(self.game_engine.rules, main_ai_gs)
-                if self.game_engine.rules.betting_round_is_over(): active_betting_round_main_loop = False
+                if self.game_engine.rules.betting_round_is_over():
+                    active_betting_round_main_loop = False
             
             print(f"Betting round for {stage_name} ended. Total actions in round: {self.game_engine.rules.actions_this_round}")
             if not self.game_engine.end_game_early: 

--- a/trainers/ai_cfr_trainer.py
+++ b/trainers/ai_cfr_trainer.py
@@ -36,7 +36,7 @@ logging.basicConfig(filename=log_file_path, level=logging.INFO, filemode='a')
 
 class AICFRTrainer:
     def __init__(self):
-        model_config = config.get('model', {}) # Get model sub-config, or empty dict
+        model_config = config.get('model', {})  # Get model sub-config, or empty dict
         hidden_dim = model_config.get('hidden_dim', 128) # Default if not found
         output_dim = model_config.get('num_actions', 10) # Default if not found
         learning_rate = model_config.get('learning_rate', 0.001) # Default if not found
@@ -54,7 +54,9 @@ class AICFRTrainer:
         )
         
         self.optimizer = optim.Adam(self.model.parameters(), lr=learning_rate)
-        self.num_actions = output_dim # Ensure this is consistent with model output
+        self.num_actions = output_dim  # Ensure this is consistent with model output
+        # Expose configuration so callers (e.g. self-play) can retrieve model params
+        self.config = config
         
         # Initialize cumulative regret and strategy tensors
         # These should be persistent across training iterations for a given state-space node if traditional CFR.

--- a/trainers/deep_cfr_trainer.py
+++ b/trainers/deep_cfr_trainer.py
@@ -49,6 +49,15 @@ class DeepCFRTrainer:
         self.num_actions = num_actions
         self.cumulative_regret = torch.zeros(num_actions)
         self.cumulative_strategy = torch.zeros(num_actions)
+        # Minimal config dict for compatibility with SelfPlay expectations
+        self.config = {
+            'model': {
+                'd_raw_feature': input_feature_dim,
+                'hidden_dim': hidden_dim,
+                'num_actions': num_actions,
+                'learning_rate': learning_rate,
+            }
+        }
 
     def store_trajectory(self, state: torch.Tensor, action: int, regret: torch.Tensor):
         self.replay_buffer.push((state.detach(), action, regret.detach()))

--- a/trainers/single_network_cfr_trainer.py
+++ b/trainers/single_network_cfr_trainer.py
@@ -19,6 +19,15 @@ class SingleNetworkCFRTrainer:
         self.num_actions = num_actions
         self.cumulative_regret = torch.zeros(num_actions)
         self.cumulative_strategy = torch.zeros(num_actions)
+        # Expose simple config for use by SelfPlay
+        self.config = {
+            'model': {
+                'd_raw_feature': input_feature_dim,
+                'hidden_dim': hidden_dim,
+                'num_actions': num_actions,
+                'learning_rate': lr,
+            }
+        }
 
     def train_step(self, state: torch.Tensor, counterfactual_payoffs: torch.Tensor):
         strategy_pred = self.model(state.unsqueeze(0)).squeeze(0)


### PR DESCRIPTION
## Summary
- expose `config` field in all trainers
- store `num_actions` on the Transformer model
- add missing fields to `GameState`
- fix AI state population and transformer input
- confirm short training run works

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `timeout 15s python run_training.py --num-hands 1 --save-model-every 1 --algorithm ai_cfr`

------
https://chatgpt.com/codex/tasks/task_b_68429fe03b3c832ab0738ff992319a49