### PR TITLE
Fix: Extend training duration and verify settings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ game_engine:
   small_blind: 5
 
 training:
-  num_training_hands: 1
+  num_training_hands: 1000
   save_model_every_n_hands: 1
   batch_size: 32 # Kept existing, though less relevant for current training loop
   num_epochs: 50 # Kept existing, though less relevant for current training loop


### PR DESCRIPTION
The training process was ending prematurely because `num_training_hands` in `config.yaml` was set to 1. This commit increases this value to 1000 to allow for more extensive training.

Additionally, verified the following:
- Model saving correctly uses the path specified in `config.yaml`.
- The number of players for each game is already randomized (2-10) as per the requirements.