### PR TITLE
Enable optional GPU support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ During training each hand uses a random number of players (between 2 and 10).
 - Betting-tree abstraction utilities
 - Discounted CFR+ solver with regret discounting
 - Distributed self-play with multiprocessing
+- Optional GPU acceleration with automatic device selection
 - Simple exploitability evaluation tools
 
 ## Using Distributed Self-Play

--- a/run_training.py
+++ b/run_training.py
@@ -5,6 +5,7 @@ import os # For path manipulation if needed, e.g. for robust config loading
 import argparse
 import random
 import time
+import torch
 
 # Assuming the script is run from the project root,
 # and trainers, self_play, etc., are packages in that root.
@@ -65,13 +66,19 @@ def parse_args() -> argparse.Namespace:
         default=CONFIG_FILE_PATH,
         help="Path to configuration YAML file"
     )
+    parser.add_argument(
+        "--device",
+        choices=["cpu", "cuda"],
+        default=None,
+        help="Computation device. Defaults to CUDA if available",
+    )
     return parser.parse_args()
 
 
-def initialize_trainer(algorithm: str, config: dict) -> AICFRTrainer:
+def initialize_trainer(algorithm: str, config: dict, device: str) -> AICFRTrainer:
     """Return a trainer instance based on selected algorithm."""
     if algorithm == "ai_cfr":
-        return AICFRTrainer()
+        return AICFRTrainer(device=device)
     elif algorithm == "deep_cfr":
         from trainers.deep_cfr_trainer import DeepCFRTrainer
         model_cfg = config.get("model", {})
@@ -79,7 +86,7 @@ def initialize_trainer(algorithm: str, config: dict) -> AICFRTrainer:
         hidden = model_cfg.get("hidden_dim", 128)
         num_actions = model_cfg.get("num_actions", 10)
         lr = model_cfg.get("learning_rate", 1e-3)
-        return DeepCFRTrainer(d_raw, hidden, num_actions, learning_rate=lr)
+        return DeepCFRTrainer(d_raw, hidden, num_actions, learning_rate=lr, device=device)
     elif algorithm == "single_network":
         from trainers.single_network_cfr_trainer import SingleNetworkCFRTrainer
         model_cfg = config.get("model", {})
@@ -87,7 +94,7 @@ def initialize_trainer(algorithm: str, config: dict) -> AICFRTrainer:
         hidden = model_cfg.get("hidden_dim", 128)
         num_actions = model_cfg.get("num_actions", 10)
         lr = model_cfg.get("learning_rate", 1e-3)
-        return SingleNetworkCFRTrainer(d_raw, hidden, num_actions, lr)
+        return SingleNetworkCFRTrainer(d_raw, hidden, num_actions, lr, device=device)
     else:
         raise ValueError(f"Unknown algorithm: {algorithm}")
 
@@ -96,6 +103,7 @@ def main():
     print("--- Starting Poker AI Training Session ---")
 
     args = parse_args()
+    device = args.device if args.device else ("cuda" if torch.cuda.is_available() else "cpu")
 
     # Load configuration
     config = load_configuration(args.config)
@@ -133,6 +141,7 @@ def main():
     print(f"Number of players: {num_players}")
     print(f"Starting stack: {starting_stack}")
     print(f"Blinds: SB={small_blind}, BB={big_blind}")
+    print(f"Using device: {device}")
     # Note: AICFRTrainer also loads config.yaml internally for its model parameters.
     # Ensure d_raw_feature is present in config.yaml for TransformerAverageStrategy if not using defaults.    # Initialization
     print("\n--- Initializing Components ---")
@@ -144,7 +153,7 @@ def main():
     }
 
     try:
-        cfr_trainer = initialize_trainer(args.algorithm, config)
+        cfr_trainer = initialize_trainer(args.algorithm, config, device)
         print(f"{args.algorithm} trainer initialized.")
         
         # Debug: Check if trainer has required attributes

--- a/self_play/self_play.py
+++ b/self_play/self_play.py
@@ -322,6 +322,8 @@ class SelfPlay:
                         max_seq_len,
                         d_raw_feature,
                     )
+                    device = getattr(self.cfr_trainer, 'device', 'cpu')
+                    state_tensor = state_tensor.to(device)
                     strategy_probs_tensor = self.cfr_trainer.model(state_tensor.unsqueeze(0)).squeeze(0)
                     if not torch.all(strategy_probs_tensor >= 0):
                         print(f"Warning: strategy_probs_tensor has negative values: {strategy_probs_tensor}. Using uniform.")
@@ -334,7 +336,10 @@ class SelfPlay:
                          else:
                              strategy_probs_tensor = strategy_probs_tensor / total
 
-                    counterfactual_payoffs = torch.zeros(self.cfr_trainer.model.num_actions)
+                    counterfactual_payoffs = torch.zeros(
+                        self.cfr_trainer.model.num_actions,
+                        device=device
+                    )
                     for k_action_idx in range(self.cfr_trainer.model.num_actions):
                         temp_engine_rules_for_k = copy.deepcopy(self.game_engine.rules)
                         temp_ai_gs_for_k = self._populate_ai_gamestate(temp_engine_rules_for_k, main_ai_gs)

--- a/tests/test_run_training.py
+++ b/tests/test_run_training.py
@@ -30,6 +30,7 @@ class TestRunTraining(unittest.TestCase):
         args_mock.num_hands = num_hands_to_simulate
         args_mock.algorithm = "ai_cfr"
         args_mock.config = "dummy_config.yaml"
+        args_mock.device = None
 
         training_params_mock = {
             'save_model_every_minutes': save_interval_minutes,
@@ -69,6 +70,7 @@ class TestRunTraining(unittest.TestCase):
         args_mock.num_hands = 5
         args_mock.algorithm = "ai_cfr"
         args_mock.config = "dummy_config.yaml"
+        args_mock.device = None
 
         training_params_mock = {
             'save_model_every_minutes': 0,
@@ -108,6 +110,7 @@ class TestRunTraining(unittest.TestCase):
         args_mock.num_hands = 5
         args_mock.algorithm = "ai_cfr"
         args_mock.config = "dummy_config.yaml"
+        args_mock.device = None
 
         training_params_mock = {
             'save_model_every_minutes': args_mock.save_minutes,
@@ -154,6 +157,7 @@ class TestRunTraining(unittest.TestCase):
         args_mock.num_hands = num_hands_to_simulate
         args_mock.algorithm = "ai_cfr"
         args_mock.config = "dummy_config.yaml"
+        args_mock.device = None
 
         # Simulate config loaded WITHOUT 'save_model_every_minutes' explicitly
         training_params_mock = {

--- a/trainers/ai_cfr_trainer.py
+++ b/trainers/ai_cfr_trainer.py
@@ -35,7 +35,8 @@ if log_dir and not os.path.exists(log_dir):
 logging.basicConfig(filename=log_file_path, level=logging.INFO, filemode='a')
 
 class AICFRTrainer:
-    def __init__(self):
+    def __init__(self, device: str | None = None):
+        self.device = device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu")
         model_config = config.get('model', {})  # Get model sub-config, or empty dict
         hidden_dim = model_config.get('hidden_dim', 128) # Default if not found
         output_dim = model_config.get('num_actions', 10) # Default if not found
@@ -46,18 +47,19 @@ class AICFRTrainer:
         d_raw_feature = model_config.get('d_raw_feature', 3) 
 
         self.model = TransformerAverageStrategy(
-            input_feature_dim=d_raw_feature, 
-            hidden_dim=hidden_dim, 
+            input_feature_dim=d_raw_feature,
+            hidden_dim=hidden_dim,
             num_heads=8,  # Assuming num_heads and num_layers are fixed or could also be in config
-            num_layers=2, 
+            num_layers=2,
             num_actions=output_dim
         )
-        
+        self.model.to(self.device)
+
         self.optimizer = optim.Adam(self.model.parameters(), lr=learning_rate)
         self.num_actions = output_dim  # Ensure this is consistent with model output
         # Expose configuration so callers (e.g. self-play) can retrieve model params
         self.config = config
-        
+
         # Initialize cumulative regret and strategy tensors
         # These should be persistent across training iterations for a given state-space node if traditional CFR.
         # For deep CFR, these are often associated with the overall training process rather than per-state.
@@ -65,8 +67,8 @@ class AICFRTrainer:
         # This means they represent the regret/strategy for the "average" state encountered, or this trainer
         # is intended for a single info set (not typical for deep CFR).
         # Given the context, these likely track average regrets/strategies over the samples seen by the network.
-        self.cumulative_regret = torch.zeros(self.num_actions)
-        self.cumulative_strategy = torch.zeros(self.num_actions)
+        self.cumulative_regret = torch.zeros(self.num_actions, device=self.device)
+        self.cumulative_strategy = torch.zeros(self.num_actions, device=self.device)
 
 
     def train(self, state_tensor: torch.Tensor, all_counterfactual_payoffs: torch.Tensor):
@@ -79,14 +81,17 @@ class AICFRTrainer:
         try:
             # Ensure state_tensor is correctly shaped for the model (batch_size=1)
             if state_tensor.ndim == 2: # Should be [seq_len, feature_dim]
-                state_tensor_batched = state_tensor.unsqueeze(0) # Add batch dimension
+                state_tensor_batched = state_tensor.unsqueeze(0)
             elif state_tensor.ndim == 3 and state_tensor.shape[0] == 1: # Already batched
                 state_tensor_batched = state_tensor
             else:
                 raise ValueError(f"state_tensor has unexpected shape: {state_tensor.shape}")
 
+            state_tensor_batched = state_tensor_batched.to(self.device)
+            all_counterfactual_payoffs = all_counterfactual_payoffs.to(self.device)
+
             # a. Get model's current strategy prediction
-            strategy_pred = self.model(state_tensor_batched).squeeze(0) # Remove batch dim for calculations
+            strategy_pred = self.model(state_tensor_batched).squeeze(0)
 
             # b. Detach strategy_pred for regret calculation
             current_model_strategy_detached = strategy_pred.detach().clone()
@@ -135,8 +140,9 @@ class AICFRTrainer:
     def load_model(self):
         # Ensure config path is correct or make it an argument
         try:
-            self.model.load_state_dict(torch.load(config['training']['save_model_path']))
-            self.model.eval() # Set model to evaluation mode
+            self.model.load_state_dict(torch.load(config['training']['save_model_path'], map_location=self.device))
+            self.model.to(self.device)
+            self.model.eval()
             logging.info(f"Model loaded from {config['training']['save_model_path']}")
         except Exception as e:
             logging.error(f"Error loading model: {str(e)}", exc_info=True)

--- a/trainers/deep_cfr_trainer.py
+++ b/trainers/deep_cfr_trainer.py
@@ -27,7 +27,8 @@ class ReplayBuffer:
 class DeepCFRTrainer:
     """Minimal Deep CFR trainer using Transformer networks."""
     def __init__(self, input_feature_dim: int, hidden_dim: int, num_actions: int, learning_rate: float = 1e-3,
-                 buffer_capacity: int = 10000):
+                 buffer_capacity: int = 10000, device: str | None = None):
+        self.device = device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu")
         self.advantage_net = TransformerAverageStrategy(
             input_feature_dim=input_feature_dim,
             hidden_dim=hidden_dim,
@@ -42,13 +43,15 @@ class DeepCFRTrainer:
             num_layers=2,
             num_actions=num_actions,
         )
+        self.advantage_net.to(self.device)
+        self.strategy_net.to(self.device)
         self.adv_optimizer = optim.Adam(self.advantage_net.parameters(), lr=learning_rate)
         self.strat_optimizer = optim.Adam(self.strategy_net.parameters(), lr=learning_rate)
 
         self.replay_buffer = ReplayBuffer(buffer_capacity)
         self.num_actions = num_actions
-        self.cumulative_regret = torch.zeros(num_actions)
-        self.cumulative_strategy = torch.zeros(num_actions)
+        self.cumulative_regret = torch.zeros(num_actions, device=self.device)
+        self.cumulative_strategy = torch.zeros(num_actions, device=self.device)
         # Minimal config dict for compatibility with SelfPlay expectations
         self.config = {
             'model': {
@@ -66,9 +69,9 @@ class DeepCFRTrainer:
         if len(self.replay_buffer) < batch_size:
             return
         batch = self.replay_buffer.sample(batch_size)
-        states = torch.stack([b[0] for b in batch])
-        actions = torch.tensor([b[1] for b in batch])
-        regrets = torch.stack([b[2] for b in batch])
+        states = torch.stack([b[0] for b in batch]).to(self.device)
+        actions = torch.tensor([b[1] for b in batch], device=self.device)
+        regrets = torch.stack([b[2] for b in batch]).to(self.device)
 
         # Train advantage network to predict regrets
         adv_pred = self.advantage_net(states)

--- a/trainers/single_network_cfr_trainer.py
+++ b/trainers/single_network_cfr_trainer.py
@@ -7,7 +7,9 @@ from rules.cfr import calculate_strategy, update_regret, update_strategy
 
 class SingleNetworkCFRTrainer:
     """CFR trainer that predicts regret and strategy with a single network."""
-    def __init__(self, input_feature_dim: int, hidden_dim: int, num_actions: int, lr: float = 1e-3):
+    def __init__(self, input_feature_dim: int, hidden_dim: int, num_actions: int, lr: float = 1e-3,
+                 device: str | None = None):
+        self.device = device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu")
         self.model = TransformerAverageStrategy(
             input_feature_dim=input_feature_dim,
             hidden_dim=hidden_dim,
@@ -15,10 +17,11 @@ class SingleNetworkCFRTrainer:
             num_layers=2,
             num_actions=num_actions,
         )
+        self.model.to(self.device)
         self.optimizer = optim.Adam(self.model.parameters(), lr=lr)
         self.num_actions = num_actions
-        self.cumulative_regret = torch.zeros(num_actions)
-        self.cumulative_strategy = torch.zeros(num_actions)
+        self.cumulative_regret = torch.zeros(num_actions, device=self.device)
+        self.cumulative_strategy = torch.zeros(num_actions, device=self.device)
         # Expose simple config for use by SelfPlay
         self.config = {
             'model': {
@@ -30,6 +33,8 @@ class SingleNetworkCFRTrainer:
         }
 
     def train_step(self, state: torch.Tensor, counterfactual_payoffs: torch.Tensor):
+        state = state.to(self.device)
+        counterfactual_payoffs = counterfactual_payoffs.to(self.device)
         strategy_pred = self.model(state.unsqueeze(0)).squeeze(0)
         state_value = torch.sum(strategy_pred.detach() * counterfactual_payoffs)
         action_regrets = counterfactual_payoffs - state_value


### PR DESCRIPTION
## Summary
- allow picking CPU or CUDA device in the training CLI
- move neural network models and tensors to the selected device
- use device during self-play policy evaluation
- mention GPU support in documentation
- adapt training tests for new CLI option

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_b_685d745d6f7c832ab743844c10a1b70e