### PR TITLE
Fix exploitability metric

### DIFF
--- a/evaluation/exploitability.py
+++ b/evaluation/exploitability.py
@@ -18,5 +18,11 @@ def calculate_exploitability(strategy: List[float], payoff_matrix: List[List[flo
     """Compute exploitability assuming payoff_matrix is zero-sum."""
     br = compute_best_response(strategy, payoff_matrix)
     br_payoff = sum(strategy[i] * payoff_matrix[br][i] for i in range(len(strategy)))
-    uniform_payoff = sum(strategy) / len(strategy)
-    return br_payoff - uniform_payoff
+
+    # Expected payoff of playing the current strategy against itself
+    strategy_payoff = 0.0
+    for i, row in enumerate(payoff_matrix):
+        row_payoff = sum(strategy[j] * row[j] for j in range(len(strategy)))
+        strategy_payoff += strategy[i] * row_payoff
+
+    return br_payoff - strategy_payoff

--- a/tests/test_exploitability.py
+++ b/tests/test_exploitability.py
@@ -7,8 +7,15 @@ def test_best_response():
     assert compute_best_response(strat, matrix) in (0, 1)
 
 
-def test_exploitability():
+def test_exploitability_zero_sum():
     strat = [0.5, 0.5]
     matrix = [[1, -1], [-1, 1]]
     expl = calculate_exploitability(strat, matrix)
-    assert abs(expl) <= 1
+    assert abs(expl - 0.0) < 1e-6
+
+
+def test_exploitability_general_matrix():
+    strat = [1.0, 0.0]
+    matrix = [[1, 2], [3, 4]]
+    expl = calculate_exploitability(strat, matrix)
+    assert abs(expl - 2.0) < 1e-6


### PR DESCRIPTION
## Summary
- correct exploitability formula to subtract the strategy payoff
- test exploitability on zero-sum and general matrices

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d96064200832a96bf6dca7fdb327b