### PR TITLE
Add monitoring tools and logging test

### DIFF
--- a/examples/exploitability_demo.py
+++ b/examples/exploitability_demo.py
@@ -1,0 +1,7 @@
+from evaluation.exploitability import calculate_exploitability
+
+if __name__ == "__main__":
+    strategy = [0.5, 0.5]
+    matrix = [[1, -1], [-1, 1]]
+    value = calculate_exploitability(strategy, matrix)
+    print(f"Exploitability: {value}")

--- a/examples/training_loss_monitor.py
+++ b/examples/training_loss_monitor.py
@@ -1,0 +1,25 @@
+import re
+import sys
+
+
+def parse_losses(log_file: str):
+    pattern = re.compile(r"Loss: ([0-9.eE+-]+)")
+    losses = []
+    with open(log_file, "r") as f:
+        for line in f:
+            m = pattern.search(line)
+            if m:
+                losses.append(float(m.group(1)))
+    return losses
+
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else "poker_ai.log"
+    losses = parse_losses(path)
+    if not losses:
+        print("No losses found in log file")
+    else:
+        print(f"Read {len(losses)} loss values")
+        print(f"Most recent 5: {losses[-5:]}")
+        avg = sum(losses) / len(losses)
+        print(f"Average loss: {avg:.6f}")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,32 @@
+import torch
+from trainers import ai_cfr_trainer
+
+
+def test_training_logs_loss(tmp_path):
+    log_file = tmp_path / "train.log"
+    model_path = tmp_path / "model.pth"
+    config = {
+        'logging': {'log_file': str(log_file)},
+        'model': {'hidden_dim': 8, 'num_actions': 2, 'learning_rate': 0.001, 'd_raw_feature': 3},
+        'training': {'save_model_path': str(model_path)}
+    }
+
+    ai_cfr_trainer.config = config
+    logger = ai_cfr_trainer.logging.getLogger()
+    logger.setLevel(ai_cfr_trainer.logging.INFO)
+    handler = ai_cfr_trainer.logging.FileHandler(log_file)
+    handler.setLevel(ai_cfr_trainer.logging.INFO)
+    logger.addHandler(handler)
+
+    trainer = ai_cfr_trainer.AICFRTrainer(device="cpu")
+
+    state = torch.zeros(5, 3)
+    payoffs = torch.tensor([1.0, -1.0])
+    trainer.train(state, payoffs)
+
+    handler.flush()
+    logger.removeHandler(handler)
+    handler.close()
+
+    contents = log_file.read_text()
+    assert "Training step completed. Loss:" in contents


### PR DESCRIPTION
## Summary
- provide `examples/exploitability_demo.py` to show exploitability calculation
- add `examples/training_loss_monitor.py` for reading recent training losses
- introduce `tests/test_logging.py` to ensure AICFRTrainer logs loss information

## Testing
- `pip install -e .`
- `pip install pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685db7e58474832a9a164208e691039b