### PR TITLE
Improve CFR traversal and self-play opponent strategy

### DIFF
--- a/cfr_trainer.py
+++ b/cfr_trainer.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 import numpy as np
 import builtins
 from texas_holdem import TexasHoldem  # Ensure this import is correct
-from rules.cfr import update_regret, update_strategy
+from rules.cfr import update_regret, update_strategy, calculate_strategy
 
 # Ensure ``round`` can handle mis-specified arguments in unit tests
 _orig_round = builtins.round
@@ -67,7 +67,10 @@ class CFRTrainer:
         regrets_tensor = torch.tensor(regrets, dtype=torch.float32)
         self.optimizer.zero_grad()
         predictions = self.model(states_tensor)
-        loss = F.mse_loss(predictions, regrets_tensor)
+        # Convert regrets into a regret-matched strategy target
+        with torch.no_grad():
+            target = torch.stack([calculate_strategy(r, self.num_actions) for r in regrets_tensor])
+        loss = F.mse_loss(predictions, target)
         loss.backward()
         self.optimizer.step()
         print("Train step completed.")  # Debug print statement
@@ -97,12 +100,19 @@ class CFRTrainer:
         action_utilities = torch.zeros(self.num_actions)
         node_utility = 0.0
 
-        # Iterate over all actions. For simplicity we apply a "check" action to
-        # generate the next state since the full environment dynamics are
-        # outside the scope of these tests.
-        for a in range(self.num_actions):
+        # Enumerate distinct actions for traversal
+        base_actions = ["fold", "call", "raise", "check"]
+        if self.num_actions <= len(base_actions):
+            actions = base_actions[:self.num_actions]
+        else:
+            actions = base_actions + ["check"] * (self.num_actions - len(base_actions))
+
+        for a, action in enumerate(actions):
             next_state = state.clone()
-            next_state.apply_action(player, "check", 0)
+            amount = 0
+            if action == "raise":
+                amount = self.config.get("raise_amount", 1)
+            next_state.apply_action(player, action, amount)
             util = self.cfr(next_state, player, iteration + 1)
             action_utilities[a] = util
             node_utility += strategy[a] * util
@@ -125,18 +135,41 @@ class CFRTrainer:
     def encode_state(self, state):
         """Convert a game state into a fixed size numpy array.
 
-        The ``TexasHoldem`` class returns numpy arrays from ``get_initial_state``
-        so this helper reshapes/pads the array to ``self.input_shape``.
+        Encodes card information along with pot size, bets and active players
+        without relying on ``np.resize``.  Output shape matches
+        ``self.input_shape``.
         """
-        if isinstance(state, np.ndarray):
-            arr = state
-        elif hasattr(state, "get_initial_state"):
-            arr = state.get_initial_state()
-        else:
-            arr = np.array(state)
+        encoded = np.zeros(self.input_shape, dtype=np.float32)
 
-        arr = np.resize(arr, self.input_shape)
-        return arr
+        if isinstance(state, np.ndarray):
+            src = state
+            slices = tuple(slice(0, min(encoded.shape[i], src.shape[i])) for i in range(len(self.input_shape)))
+            encoded[slices] = src[slices]
+            return encoded
+
+        if isinstance(state, TexasHoldem):
+            card_tensor = state.get_initial_state()[0]  # remove batch dim
+            h = min(encoded.shape[0] - 1, card_tensor.shape[0])
+            w = min(encoded.shape[1], card_tensor.shape[1])
+            c = min(encoded.shape[2], card_tensor.shape[2])
+            encoded[:h, :w, :c] = card_tensor[:h, :w, :c]
+
+            feature_row = h
+            if feature_row < encoded.shape[0]:
+                encoded[feature_row, 0, 0] = state.pot
+                encoded[feature_row, 1, 0] = state.current_bet
+                for i, bet in enumerate(state.bets):
+                    col = i + 2
+                    if col < encoded.shape[1]:
+                        encoded[feature_row, col, 0] = bet
+                    if col < encoded.shape[1] and encoded.shape[2] > 1:
+                        encoded[feature_row, col, 1] = 1.0 if state.players_active[i] else 0.0
+            return encoded
+
+        arr = np.array(state)
+        slices = tuple(slice(0, min(encoded.shape[i], arr.shape[i])) for i in range(len(self.input_shape)))
+        encoded[slices] = arr[slices]
+        return encoded
 
     def save_model(self, model_path):
         os.makedirs(os.path.dirname(model_path), exist_ok=True)

--- a/src/poker_ai/selfplay/self_play.py
+++ b/src/poker_ai/selfplay/self_play.py
@@ -7,7 +7,6 @@ from utils.state_representation import prepare_transformer_input
 from utils.action_mapping import get_action_from_index
 import torch
 import copy
-import random # Added import
 from typing import List, Tuple, Dict, Any
 import os
 import json
@@ -18,6 +17,17 @@ from poker_ai.ai.models.transformer import TransformerAverageStrategy
 class DummyStrategy:
     def choose_action(self, game_rules_obj: TexasHoldemRules, player_index: int) -> Tuple[str, int | None]:
         return 'fold', None
+
+class RuleBasedStrategy:
+    """Deterministic opponent strategy for self-play."""
+    def choose_action(self, game_rules_obj: TexasHoldemRules, player_index: int) -> Tuple[str, int | None]:
+        amount_to_call = game_rules_obj.current_bet - game_rules_obj.bets[player_index]
+        player_chips = game_rules_obj.player_chips[player_index]
+        if amount_to_call > 0:
+            if player_chips >= amount_to_call:
+                return 'call', None
+            return 'fold', None
+        return 'check', None
 
 class SelfPlay:
     """Orchestrates a single poker game used for training."""
@@ -37,6 +47,7 @@ class SelfPlay:
         # Apply blind settings after creation to avoid unexpected kwargs
         self.game_engine.rules.big_blind = game_engine_config.get('big_blind', 10)
         self.game_engine.rules.small_blind = game_engine_config.get('small_blind', 5)
+        self.opponent_strategy = RuleBasedStrategy()
 
     def _is_action_valid(self, engine_rules: TexasHoldemRules, player_idx: int, action_str: str, amount: int | None) -> bool:
         player_chips = engine_rules.player_chips[player_idx]
@@ -113,90 +124,17 @@ class SelfPlay:
         return ai_gs
 
     def _get_opponent_action(self, engine_rules_obj: TexasHoldemRules, player_index: int) -> Tuple[str, int | None]:
-        player_chips = engine_rules_obj.player_chips[player_index]
-        player_current_bet_in_round = engine_rules_obj.bets[player_index]
-        game_current_bet = engine_rules_obj.current_bet
-        amount_to_call = game_current_bet - player_current_bet_in_round
-
-        chosen_action_str = 'fold' # Default safe action
-        chosen_amount_for_engine = None
-
-        if amount_to_call == 0: # Can check or bet
-            rand_val = random.random()
-            if rand_val < 0.7: # 70% chance to check
-                chosen_action_str, chosen_amount_for_engine = 'check', None
-            else: # 30% chance to bet
-                bet_total_amount = int(engine_rules_obj.pot * 0.5)
-                bet_total_amount = max(bet_total_amount, engine_rules_obj.big_blind)
-                bet_total_amount = min(bet_total_amount, player_chips) # Cap at player's stack
-
-                if self._is_action_valid(engine_rules_obj, player_index, 'bet', bet_total_amount):
-                    chosen_action_str, chosen_amount_for_engine = 'bet', bet_total_amount
-                else: # Bet is invalid (e.g. player_chips is 0, or calculated bet is 0 and invalid)
-                    chosen_action_str, chosen_amount_for_engine = 'check', None # Fallback to check
-        else: # Facing a bet/raise (amount_to_call > 0)
-            rand_val = random.random()
-            if rand_val < 0.1: # 10% chance to fold
-                chosen_action_str, chosen_amount_for_engine = 'fold', None
-            elif rand_val < 0.3: # 20% chance to attempt raise (cumulative 0.1 + 0.2 = 0.3)
-                # Try to raise: e.g., raise by 75% of current pot size, min increment is big blind
-                raise_increment = int(engine_rules_obj.pot * 0.75)
-                raise_increment = max(raise_increment, engine_rules_obj.big_blind)
-                raise_increment = min(raise_increment, player_chips - amount_to_call) # Cap increment if it makes player all-in
-
-                if raise_increment <=0 : # cannot make a positive raise increment (e.g. already all in to call)
-                    # Fallback to call if possible
-                    if self._is_action_valid(engine_rules_obj, player_index, 'call', game_current_bet):
-                         chosen_action_str, chosen_amount_for_engine = 'call', None # Engine calculates call amount
-                    else: # Cannot call
-                         chosen_action_str, chosen_amount_for_engine = 'fold', None
-                else:
-                    # Validate the proposed raise. `_is_action_valid` for 'raise' expects the *total* bet amount.
-                    proposed_total_bet_for_validation = game_current_bet + raise_increment
-                    if self._is_action_valid(engine_rules_obj, player_index, 'raise', proposed_total_bet_for_validation):
-                        chosen_action_str, chosen_amount_for_engine = 'raise', raise_increment
-                    else: # Raise is invalid or unaffordable, try to call
-                        if self._is_action_valid(engine_rules_obj, player_index, 'call', game_current_bet):
-                            chosen_action_str, chosen_amount_for_engine = 'call', None
-                        else: # Cannot call
-                            chosen_action_str, chosen_amount_for_engine = 'fold', None
-            else: # 70% chance to call
-                if self._is_action_valid(engine_rules_obj, player_index, 'call', game_current_bet):
-                    chosen_action_str, chosen_amount_for_engine = 'call', None
-                else: # Cannot call
-                    chosen_action_str, chosen_amount_for_engine = 'fold', None
-        
-        # Final safety net: if chosen action is somehow still invalid, default to fold or check.
-        # This logic should ideally be covered by the decision paths above.
-        # For 'call', _is_action_valid needs the total bet amount (game_current_bet)
-        # For 'bet', _is_action_valid needs the total bet amount
-        # For 'raise', _is_action_valid needs the total bet amount
-        # The `chosen_amount_for_engine` is what process_action expects (None for call, total for bet, increment for raise)
-        
-        # Re-construct the 'amount' argument for _is_action_valid based on action type
-        amount_for_validation = None
-        if chosen_action_str == 'bet':
-            amount_for_validation = chosen_amount_for_engine
-        elif chosen_action_str == 'raise':
-            # Must calculate total bet for validation if chosen_amount_for_engine is the increment
-            if chosen_amount_for_engine is not None:
-                 amount_for_validation = game_current_bet + chosen_amount_for_engine
-            else: # Should not happen if raise is chosen with None amount
-                 pass # Keep it None, will likely fail validation or be fold
-        elif chosen_action_str == 'call':
-            amount_for_validation = game_current_bet # Call is to match current game bet
-
-        if not self._is_action_valid(engine_rules_obj, player_index, chosen_action_str, amount_for_validation):
-            # print(f"Warning: Opponent action {chosen_action_str}, {chosen_amount_for_engine} (valid. amount: {amount_for_validation}) was chosen but is invalid. Fallback.")
-            if amount_to_call == 0: # Original situation was check/bet
-                chosen_action_str, chosen_amount_for_engine = 'check', None
-            # Check if player can call the original amount_to_call
-            elif self._is_action_valid(engine_rules_obj, player_index, 'call', game_current_bet):
-                chosen_action_str, chosen_amount_for_engine = 'call', None
-            else: # Must fold
-                chosen_action_str, chosen_amount_for_engine = 'fold', None
-                
-        return chosen_action_str, chosen_amount_for_engine
+        """Return an action for an opponent player using a rule-based policy."""
+        action_str, amount = self.opponent_strategy.choose_action(engine_rules_obj, player_index)
+        if action_str == 'call':
+            validation_amount = engine_rules_obj.current_bet
+        else:
+            validation_amount = amount
+        if not self._is_action_valid(engine_rules_obj, player_index, action_str, validation_amount):
+            if self._is_action_valid(engine_rules_obj, player_index, 'check', None):
+                return 'check', None
+            return 'fold', None
+        return action_str, amount
 
     def _simulate_hand_outcome(self, temp_game_engine_state: TexasHoldemRules, ai_player_idx_for_payoff: int) -> float:
         sim_engine = TexasHoldem(**self.game_engine_base_config)
@@ -425,8 +363,15 @@ class SelfPlay:
         if not training_data_for_hand:
             print("No training data (AI decision points) collected for this hand.")
         for state_tensor_data, _, _, cf_payoffs_data in training_data_for_hand:
-            print(f"Calling cfr_trainer.train with state_tensor shape: {state_tensor_data.shape}, cf_payoffs: {cf_payoffs_data.tolist()}")
-            self.cfr_trainer.train(state_tensor_data, cf_payoffs_data)
+            print(
+                f"Calling cfr_trainer.train with state_tensor shape: {state_tensor_data.shape}, cf_payoffs: {cf_payoffs_data.tolist()}"
+            )
+            train_fn = self.cfr_trainer.train
+            if train_fn.__code__.co_argcount == 3:  # self, state_tensor, cf_payoffs
+                train_fn(state_tensor_data, cf_payoffs_data)
+            else:
+                info_set_id = str(state_tensor_data.tolist())
+                train_fn(info_set_id, state_tensor_data, cf_payoffs_data)
         
         print("\nHand complete.")
         return training_data_for_hand


### PR DESCRIPTION
## Summary
- Distinguish fold/call/raise/check branches in CFR traversal and learn regret-matched policies
- Encode card, pot, bet, and active-player features without using numpy resize
- Replace random self-play opponent with deterministic rule-based strategy
- Allow self-play to handle trainers with or without info-set identifiers

## Testing
- `pytest tests`
- `python training/train.py --num-hands 1`
- `timeout 5 python -u human_vs_ai.py --total-players 2 --num-humans 0 --starting-stack 1000`


------
https://chatgpt.com/codex/tasks/task_b_689971774d1c832a9db14702ec03db15