### PR TITLE
Add model-backed strategy for CLI play

### DIFF
--- a/src/poker_ai/cli/play.py
+++ b/src/poker_ai/cli/play.py
@@ -3,9 +3,19 @@
 """Command line game allowing humans to play against simple AI players."""
 
 import argparse
+import json
+import os
 import sys
+
+import torch
+
+from poker_ai.ai.models.transformer import AdvantageNetwork
 from poker_ai.engine.texas_holdem import TexasHoldem
-from poker_ai.gui.playStrategy import HumanStrategy, RandomAIStrategy
+from poker_ai.gui.playStrategy import (
+    HumanStrategy,
+    ModelAIStrategy,
+    RandomAIStrategy,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -14,11 +24,40 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--total-players", type=int, help="Total number of players (2-10)")
     parser.add_argument("--num-humans", type=int, help="Number of human players")
     parser.add_argument("--starting-stack", type=int, default=10000, help="Starting chip count")
+    parser.add_argument(
+        "--model-path",
+        type=str,
+        help="Path to saved AdvantageNetwork weights (.pth) to control AI players",
+    )
     return parser.parse_args()
+
+
+def load_model(model_path: str) -> ModelAIStrategy:
+    """Load a saved :class:`AdvantageNetwork` and wrap it in ``ModelAIStrategy``."""
+    config_path = os.path.splitext(model_path)[0] + ".config.json"
+    with open(config_path, "r") as f:
+        model_config = json.load(f)
+
+    network_params = {
+        k: model_config[k]
+        for k in [
+            "input_feature_dim",
+            "hidden_dim",
+            "num_heads",
+            "num_layers",
+            "num_actions",
+        ]
+    }
+    model = AdvantageNetwork(**network_params)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.load_state_dict(torch.load(model_path, map_location=device))
+    return ModelAIStrategy(model, model_config, device)
 
 def main() -> None:
     args = parse_args()
     print("=== Welcome to Texas Hold'em Poker Simulation ===\n")
+
+    model_strategy = load_model(args.model_path) if args.model_path else None
 
     total_players = args.total_players
     if total_players is None:
@@ -69,7 +108,10 @@ def main() -> None:
     for i in range(num_humans):
         player_strategies.append(HumanStrategy())
     for i in range(num_ai):
-        player_strategies.append(RandomAIStrategy())
+        if model_strategy:
+            player_strategies.append(model_strategy)
+        else:
+            player_strategies.append(RandomAIStrategy())
 
     # Instantiate the game with chosen starting stack
     game = TexasHoldem(total_players, starting_stack, player_strategies)

--- a/src/poker_ai/gui/__init__.py
+++ b/src/poker_ai/gui/__init__.py
@@ -8,7 +8,12 @@ directly and provide a thin wrapper for ``PokerGameGUI`` that imports the heavy
 module only on demand.
 """
 
-from .playStrategy import PlayerStrategy, RandomAIStrategy, HumanStrategy
+from .playStrategy import (
+    PlayerStrategy,
+    RandomAIStrategy,
+    HumanStrategy,
+    ModelAIStrategy,
+)
 
 
 def PokerGameGUI(*args, **kwargs):  # pragma: no cover - simple wrapper
@@ -22,4 +27,5 @@ __all__ = [
     "PlayerStrategy",
     "RandomAIStrategy",
     "HumanStrategy",
+    "ModelAIStrategy",
 ]

--- a/src/poker_ai/gui/playStrategy.py
+++ b/src/poker_ai/gui/playStrategy.py
@@ -1,6 +1,13 @@
 # playStrategy.py
 
 import random
+from typing import Dict
+
+import torch
+
+from poker_ai.ai.models.transformer import AdvantageNetwork
+from poker_ai.utils.action_mapping import get_action_from_index, get_legal_actions_mask
+from poker_ai.utils.state_representation import prepare_transformer_input
 
 # Import the new AI GTO display function lazily inside HumanStrategy to avoid
 # pulling heavy GUI dependencies when simply importing this module.
@@ -38,6 +45,46 @@ class RandomAIStrategy(PlayerStrategy):
             return action, raise_amount
         return action, None
 
+
+class ModelAIStrategy(PlayerStrategy):
+    """Strategy driven by a trained :class:`AdvantageNetwork`."""
+
+    def __init__(self, model: AdvantageNetwork, config: Dict, device: torch.device):
+        self.model = model.to(device)
+        self.model.eval()
+        self.config = config
+        self.device = device
+
+    @property
+    def is_human(self) -> bool:
+        return False
+
+    @torch.no_grad()
+    def choose_action(self, game, player_index):
+        max_seq_len = self.config.get("max_seq_len", 256)
+        d_raw_feature = self.config.get(
+            "d_raw_feature", self.config.get("input_feature_dim", 18)
+        )
+        state_tensor = prepare_transformer_input(
+            game, player_index, max_seq_len, d_raw_feature
+        )
+        advantages = (
+            self.model(state_tensor.unsqueeze(0).to(self.device))
+            .squeeze(0)
+            .cpu()
+        )
+        num_actions = self.config.get("num_actions", self.model.num_actions)
+        legal_mask = get_legal_actions_mask(game, player_index, num_actions)
+
+        advantages[~legal_mask] = -float("inf")
+        positive = torch.clamp(advantages, min=0) * legal_mask.float()
+        if positive.sum() > 0:
+            policy = positive / positive.sum()
+        else:
+            policy = legal_mask.float() / legal_mask.sum()
+
+        action_idx = torch.multinomial(policy, 1).item()
+        return get_action_from_index(action_idx, game, player_index)
 
 class HumanStrategy(PlayerStrategy):
     @property


### PR DESCRIPTION
## Summary
- allow `cli/play.py` to load a saved AdvantageNetwork via `--model-path`
- introduce `ModelAIStrategy` that evaluates the model and selects legal actions
- export the new strategy for GUI clients

## Testing
- `pytest tests/test_action_mapping.py tests/test_model_forward_pass.py -q` *(fails: AttributeError: 'DummyGameState' object has no attribute 'rules')*
- `pytest tests/test_model_forward_pass.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68ac775d4e70832a85b4ceedd53cfd4e