### PR TITLE
Fix training entry points and default feature size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,9 +28,12 @@ All production code now lives under `src/poker_ai` to allow modular development.
    ```
 
 2. **Run training**:
-   ```bash
-   python -m poker_ai.cli.train
-   ```
+    ```bash
+    python run_training.py
+    ```
+    The `run_training.py` wrapper ensures the `poker_ai` package can be imported
+    without installing the project. You can still invoke the module directly
+    with `python -m poker_ai.cli.train` if the package is installed.
 
 ### Training CLI Options
 
@@ -55,16 +58,23 @@ During training each hand uses a random number of players (between 2 and 10).
    ```
 
 5. **Command-line play simulation**:
-   ```bash
-   python -m poker_ai.cli.play --total-players 2 --num-humans 1 --starting-stack 1000
-   ```
-   The script falls back to interactive prompts if arguments are omitted.
+    ```bash
+    python -m poker_ai.cli.play --total-players 2 --num-humans 1 --starting-stack 1000
+    ```
+    The script falls back to interactive prompts if arguments are omitted.
 
-   After installation via `setup.py`, you can also use the entry points:
-   ```bash
-   play-poker --total-players 2 --num-humans 1
-   train-poker --num-hands 500
-  ```
+6. **AI self-play without humans**:
+    ```bash
+    python self_play.py
+    ```
+    This runs continuous self-play using the latest model weights and saves
+    simulated game histories.
+
+    After installation via `setup.py`, you can also use the entry points:
+    ```bash
+    play-poker --total-players 2 --num-humans 1
+    train-poker --num-hands 500
+    ```
 
 ### Trained Model
 

--- a/run_training.py
+++ b/run_training.py
@@ -1,3 +1,14 @@
+"""Entry point for launching training without requiring package installation."""
+
+import os
+import sys
+
+# Ensure the `src` directory is on the Python path so that the `poker_ai` package
+# can be imported when this script is executed directly from the repository
+# root.  This avoids ``ModuleNotFoundError`` when the project hasn't been
+# installed as a package.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
 from poker_ai.cli.train import main
 
 if __name__ == "__main__":

--- a/self_play.py
+++ b/self_play.py
@@ -1,3 +1,13 @@
+"""Entry point for launching self-play without requiring package installation."""
+
+import os
+import sys
+
+# Allow running from the repository root by ensuring the `src` directory is on
+# ``sys.path`` so that the ``poker_ai`` package can be imported without a prior
+# installation step.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
 from poker_ai.cli.self_play import main
 
 if __name__ == "__main__":

--- a/src/poker_ai/cli/train.py
+++ b/src/poker_ai/cli/train.py
@@ -97,7 +97,11 @@ def initialize_trainer(algorithm: str, config: dict, device: str, use_all_npus: 
     elif algorithm == "deep_cfr":
         from poker_ai.ai.trainers.deep_cfr_trainer import DeepCFRTrainer
         model_cfg = config.get("model", {})
-        d_raw = model_cfg.get("d_raw_feature", 3)
+        # Default to 18 raw features so that card one-hot encodings fit even if
+        # the configuration file cannot be loaded (e.g. when PyYAML is not
+        # installed).  Using a smaller default previously resulted in repeated
+        # warnings from ``prepare_transformer_input``.
+        d_raw = model_cfg.get("d_raw_feature", 18)
         hidden = model_cfg.get("hidden_dim", 128)
         num_actions = model_cfg.get("num_actions", 10)
         lr = model_cfg.get("learning_rate", 1e-3)
@@ -105,7 +109,9 @@ def initialize_trainer(algorithm: str, config: dict, device: str, use_all_npus: 
     elif algorithm == "single_network":
         from poker_ai.ai.trainers.single_network_cfr_trainer import SingleNetworkCFRTrainer
         model_cfg = config.get("model", {})
-        d_raw = model_cfg.get("d_raw_feature", 3)
+        # Match the default described above for Deep CFR to ensure consistent
+        # feature dimensions across training approaches.
+        d_raw = model_cfg.get("d_raw_feature", 18)
         hidden = model_cfg.get("hidden_dim", 128)
         num_actions = model_cfg.get("num_actions", 10)
         lr = model_cfg.get("learning_rate", 1e-3)


### PR DESCRIPTION
## Summary
- Ensure training and self-play scripts modify `sys.path` so `poker_ai` can be imported without installation
- Default DeepCFR and single-network trainers to 18 raw features to avoid repeated feature-size warnings
- Document standalone `run_training.py` and `self_play.py` wrappers in the README

## Testing
- `pip install treys`
- `python run_training.py --num-hands 1`
- `python self_play.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac65f5b77c832ab1e97bfa2a3b9fb7