### PR TITLE
Add foundational tests for core engine and utilities

### DIFF
--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+import pytest
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+src_path = os.path.join(project_root, "src")
+for p in (project_root, src_path):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from gatc_holdem.core.actions import Action, ActionType  # noqa: E402
+
+
+def test_action_requires_amount_for_bet_like() -> None:
+    with pytest.raises(ValueError):
+        Action(ActionType.BET)
+    with pytest.raises(ValueError):
+        Action(ActionType.RAISE, amount_to=-5)
+    with pytest.raises(ValueError):
+        Action(ActionType.ALL_IN, amount_to=-1)
+
+
+def test_check_and_call_do_not_need_amount() -> None:
+    Action(ActionType.CHECK)
+    Action(ActionType.CALL)

--- a/tests/test_cli_train.py
+++ b/tests/test_cli_train.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+src_path = os.path.join(project_root, "src")
+
+
+def test_cli_train_runs_without_config(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.yaml"
+    cmd = [sys.executable, "-m", "poker_ai.cli.train", "--num-hands", "0", "--config", str(missing)]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [env.get("PYTHONPATH"), project_root, src_path])
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    assert result.returncode == 0
+    assert "Using default configurations" in result.stdout

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -1,0 +1,33 @@
+import os
+import random
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+src_path = os.path.join(project_root, "src")
+for p in (project_root, src_path):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from poker_ai.engine.deck import Deck  # noqa: E402
+
+
+def test_generate_deck_unique() -> None:
+    deck = Deck()
+    assert len(deck.cards) == 52
+    assert len(set(deck.cards)) == 52
+
+
+def test_shuffle_changes_order() -> None:
+    deck = Deck()
+    original = deck.cards.copy()
+    random.seed(0)
+    deck.shuffle()
+    assert deck.cards != original
+
+
+def test_deal_reduces_deck_size() -> None:
+    deck = Deck()
+    deck.shuffle()
+    dealt = deck.deal(5)
+    assert len(dealt) == 5
+    assert len(deck.cards) == 47

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+src_path = os.path.join(project_root, "src")
+for p in (project_root, src_path):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from poker_ai.engine.game_state import GameState  # noqa: E402
+
+
+class DummyPlayer:
+    def __init__(self, player_id: int) -> None:
+        self.player_id = player_id
+
+
+def test_game_state_operations() -> None:
+    state = GameState()
+    players = [DummyPlayer(i) for i in range(3)]
+    state.set_players(players)
+    assert state.player_order == ["0", "1", "2"]
+    assert state.get_player(1) is players[1]
+    state.set_player_hand(1, ["As", "Kd"])
+    assert state.player_hands[1] == ["As", "Kd"]
+    state.add_community_cards(["Qh", "Jh"])
+    assert state.community_cards == ["Qh", "Jh"]
+    state.record_action(1, ("bet", 100))
+    assert state.betting_history[-1] == (1, ("bet", 100))
+    state.set_current_bet(150)
+    assert state.current_bet == 150

--- a/tests/test_handeval_extra.py
+++ b/tests/test_handeval_extra.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+import pytest
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+src_path = os.path.join(project_root, "src")
+for p in (project_root, src_path):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from gatc_poker.handeval import evaluate_hand  # noqa: E402
+
+
+def test_invalid_card_string() -> None:
+    with pytest.raises(ValueError):
+        evaluate_hand(["1x", "Ac"], ["Ad", "Kd", "Qd"])
+
+
+def test_duplicate_cards() -> None:
+    with pytest.raises(ValueError):
+        evaluate_hand(["As", "Ac"], ["Ad", "Ks", "As"])
+
+
+def test_min_and_max_cards() -> None:
+    assert isinstance(evaluate_hand(["As", "Kd"], ["2c", "3d", "4h"]), int)
+    assert isinstance(evaluate_hand(["As", "Kd"], ["2c", "3d", "4h", "5s", "6c"]), int)

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+src_path = os.path.join(project_root, "src")
+for p in (project_root, src_path):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from poker_ai.engine.player import Player  # noqa: E402
+
+
+def test_player_bet_caps_at_stack() -> None:
+    p = Player(player_id=0, stack_size=100)
+    assert p.bet(40) == 40
+    assert p.stack_size == 60
+    assert p.current_bet == 40
+    assert p.bet(80) == 60
+    assert p.stack_size == 0
+    assert p.current_bet == 100

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+src_path = os.path.join(project_root, "src")
+for p in (project_root, src_path):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from gatc_holdem.engine.state import GameState, PlayerState  # noqa: E402
+
+
+def test_reset_street_resets_bets() -> None:
+    players = [PlayerState(stack=100, committed=50) for _ in range(2)]
+    state = GameState(
+        big_blind=100,
+        dealer_index=0,
+        street="flop",
+        current_bet_to=200,
+        last_raise_size=100,
+        last_aggressor=1,
+        players=players,
+    )
+    state.reset_street("turn")
+    assert state.street == "turn"
+    assert state.current_bet_to == 0
+    assert state.last_raise_size == 0
+    assert state.last_aggressor is None
+    assert all(p.committed == 0 for p in state.players)


### PR DESCRIPTION
## Summary
- add unit tests for action validation, street reset, deck operations, game state helpers, and player betting
- cover hand evaluation edge cases and CLI training defaults

## Testing
- `pre-commit run --files tests/test_actions.py tests/test_cli_train.py tests/test_deck.py tests/test_game_state.py tests/test_handeval_extra.py tests/test_player.py tests/test_state.py`
- `pytest tests/test_actions.py tests/test_cli_train.py tests/test_deck.py tests/test_game_state.py tests/test_handeval_extra.py tests/test_player.py tests/test_state.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68b94098cc14832abaa709e35b4422ec