### PR TITLE
Add pre-commit quality gates with ruff, mypy, bandit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -16,9 +18,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
-      - name: Lint
+      - name: Quality
         run: |
-          ruff check .
-          black --check .
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
+          else
+            pre-commit run --from-ref HEAD^ --to-ref HEAD
+          fi
       - name: Tests
         run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,14 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
     hooks:
-      - id: black
-        language_version: python3
+      - id: mypy
+        args: [--ignore-missing-imports]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.9
+    hooks:
+      - id: bandit
+        args: ["-ll"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,18 +20,14 @@ dependencies = [
 dev = [
     "pytest>=8.2",
     "hypothesis>=6.112",
-    "black>=24.8",
     "ruff>=0.6",
     "mypy>=1.10",
+    "bandit>=1.7",
     "pre-commit>=3.7",
 ]
 
 [tool.setuptools.packages.find]
 where = ["src"]
-
-[tool.black]
-line-length = 100
-target-version = ["py310", "py311"]
 
 [tool.ruff]
 line-length = 100
@@ -41,6 +37,10 @@ select = ["E","F","W","I","UP","B","C90","N","ANN"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["gatc_poker"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "-q"


### PR DESCRIPTION
## Summary
- run ruff lint & formatting, mypy and bandit through pre-commit
- hook pre-commit into CI to check only changed files
- configure mypy and dev dependencies

## Testing
- `pre-commit run --files .pre-commit-config.yaml pyproject.toml .github/workflows/ci.yml`
- `pre-commit run --files src/gatc_poker/handeval.py .pre-commit-config.yaml pyproject.toml .github/workflows/ci.yml` *(after reverting a temporary failing check)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4ec173584832aa379c98cd4bfb363