### PR TITLE
Package card images and gate GUI tests for CI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/poker_ai/gui/card_images *.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ known-first-party = ["gatc_poker"]
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
+markers = [
+    "gui: tests that require a graphical display",
+]

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ setup(
     version="1.0",
     packages=find_packages("src"),
     package_dir={"": "src"},
+    include_package_data=True,
+    package_data={"poker_ai.gui": ["card_images/*.png"]},
     install_requires=[
         "numpy",
         "torch",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest configuration for GUI-related tests."""
+import os
+from pathlib import Path
+
+import pytest
+
+# Directory containing bundled card images
+CARD_IMAGES_DIR = Path(__file__).resolve().parent.parent / "src" / "poker_ai" / "gui" / "card_images"
+
+
+def pytest_runtest_setup(item):
+    """Skip GUI tests when prerequisites are missing."""
+    if "gui" in item.keywords:
+        # Ensure card images are available
+        if not CARD_IMAGES_DIR.exists() or len(list(CARD_IMAGES_DIR.glob("*.png"))) < 52:
+            pytest.skip("card images not available")
+        # Ensure a display is available (e.g., via Xvfb)
+        if not os.environ.get("DISPLAY"):
+            pytest.skip("no display available for GUI test")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -3,11 +3,15 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 src_path = os.path.join(project_root, "src")
 for p in (src_path, project_root):
     if p not in sys.path:
         sys.path.insert(0, p)
+
+pytestmark = pytest.mark.gui
 
 # Conditional import of PokerGameGUI for testing
 # This allows the test file to be parsed even if tkinter is not available in the environment

--- a/tests/test_gui_core.py
+++ b/tests/test_gui_core.py
@@ -8,12 +8,16 @@ import sys
 import unittest
 from unittest.mock import Mock, patch
 
+import pytest
+
 # Add project root to path
-project_root = os.path.abspath(os.path.dirname(__file__))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 src_path = os.path.join(project_root, "src")
 for p in (src_path, project_root):
     if p not in sys.path:
         sys.path.insert(0, p)
+
+pytestmark = pytest.mark.gui
 
 
 class TestGUICore(unittest.TestCase):

--- a/tests/test_gui_functionality.py
+++ b/tests/test_gui_functionality.py
@@ -3,12 +3,16 @@ import sys
 import unittest
 from unittest.mock import MagicMock, call, patch
 
+import pytest
+
 # Add project root to sys.path
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 src_path = os.path.join(project_root, "src")
 for p in (src_path, project_root):
     if p not in sys.path:
         sys.path.insert(0, p)
+
+pytestmark = pytest.mark.gui
 
 # Mock tkinter before importing GUI
 try:


### PR DESCRIPTION
## Summary
- Include bundled card image assets in built packages
- Mark GUI tests and skip them when no display or images are available
- Ensure simple GUI core tests run under Xvfb

## Testing
- `pytest -m 'not gui' tests/test_gui_core.py`
- `pytest -m gui tests/test_gui_core.py`
- `xvfb-run -a pytest -m gui tests/test_gui_core.py`

------
https://chatgpt.com/codex/tasks/task_b_68c4ec736140832a9cd4a40b68c66fdb