### PR TITLE
Add deterministic seeding utilities and tests

### DIFF
--- a/src/poker_ai/utils/__init__.py
+++ b/src/poker_ai/utils/__init__.py
@@ -1,6 +1,7 @@
-from .abstraction import *
+from .abstraction import *  # noqa: F401,F403
 from .action_mapping import get_action_from_index
-from .betting_system import *
+from .betting_system import *  # noqa: F401,F403
+from .seeding import set_seed
 from .state_representation import CardSetTransformer, prepare_transformer_input
 
-__all__ = ["get_action_from_index", "prepare_transformer_input", "CardSetTransformer"]
+__all__ = ["get_action_from_index", "prepare_transformer_input", "CardSetTransformer", "set_seed"]

--- a/src/poker_ai/utils/seeding.py
+++ b/src/poker_ai/utils/seeding.py
@@ -1,0 +1,15 @@
+import random
+
+import numpy as np
+import torch
+
+
+def set_seed(seed: int) -> None:
+    """Set seed for random, numpy, and torch for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+import pytest
+
+# Ensure project root and src are in path for imports
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+for p in (SRC_PATH, PROJECT_ROOT):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from poker_ai.utils.seeding import set_seed  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def global_seed() -> None:
+    """Seed random number generators for every test."""
+    seed = int(os.getenv("PYTEST_SEED", "0"))
+    set_seed(seed)

--- a/tests/test_deterministic_seeding.py
+++ b/tests/test_deterministic_seeding.py
@@ -1,0 +1,37 @@
+import random
+
+import numpy as np
+import torch
+
+from poker_ai.utils.seeding import set_seed
+
+ACTIONS = ["fold", "call", "raise"]
+
+
+def generate_action_sequence(length: int = 5) -> list[str]:
+    """Generate a pseudo-random action sequence using random, numpy, and torch."""
+    sequence: list[str] = []
+    for _ in range(length):
+        idx = (
+            int(random.random() * len(ACTIONS))
+            + int(np.random.rand() * len(ACTIONS))
+            + int(torch.rand(1).item() * len(ACTIONS))
+        ) % len(ACTIONS)
+        sequence.append(ACTIONS[idx])
+    return sequence
+
+
+def test_action_sequence_reproducible() -> None:
+    set_seed(123)
+    seq1 = generate_action_sequence()
+    set_seed(123)
+    seq2 = generate_action_sequence()
+    assert seq1 == seq2
+
+
+def test_action_sequence_varies_with_seed() -> None:
+    set_seed(123)
+    seq1 = generate_action_sequence()
+    set_seed(456)
+    seq2 = generate_action_sequence()
+    assert seq1 != seq2


### PR DESCRIPTION
## Summary
- Add `set_seed` utility to seed Python, NumPy, and PyTorch RNGs for reproducible runs
- Automatically seed tests via global fixture with optional `PYTEST_SEED` override
- Verify deterministic behavior with new action sequence tests

## Testing
- `pre-commit run --files tests/conftest.py src/poker_ai/utils/seeding.py tests/test_deterministic_seeding.py src/poker_ai/utils/__init__.py`
- `pytest tests/test_deterministic_seeding.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4ec6219e0832ab6fa3b9a027b0619