### PR TITLE
ci: enable dependabot and secret scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,16 @@
+name: Secret Scanning
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gitleaks/gitleaks-action@v2
+        with:
+          args: --redact


### PR DESCRIPTION
## Summary
- add dependabot configuration for GitHub Actions and pip dependencies
- add gitleaks-based secret scanning workflow

## Testing
- `pre-commit run --files .github/dependabot.yml .github/workflows/secret-scanning.yml`
- `pytest test_simple.py`


------
https://chatgpt.com/codex/tasks/task_b_68c4f354d1dc832abe9c54f54ed87760