### PR TITLE
Add containerized FastAPI health endpoint

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,27 @@
+name: build-container
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -t answers .
+      - name: Run container and test health
+        run: |
+          docker run -d --rm -p 8000:8000 --name answers answers
+          for i in {1..10}; do
+            if curl --fail http://localhost:8000/healthz; then
+              success=1
+              break
+            fi
+            sleep 1
+          done
+          docker stop answers
+          test "$success" = "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS builder
+WORKDIR /app
+COPY docker/requirements.txt ./requirements.txt
+RUN pip wheel --no-cache-dir --wheel-dir /wheels -r requirements.txt
+
+FROM python:3.11-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+# install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+# create non-root user
+RUN useradd --create-home appuser
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache /wheels/*
+COPY app.py .
+EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=3s CMD curl --fail http://localhost:8000/healthz || exit 1
+USER appuser
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app.py
+++ b/app.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    """Return a simple health indicator."""
+    return {"status": "ok"}

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- add FastAPI `app.py` with `/healthz` endpoint
- create multi-stage Dockerfile using python:slim and non-root user
- add GitHub Actions workflow to build image and curl the health endpoint

## Testing
- `pre-commit run --files app.py Dockerfile .github/workflows/build-container.yml docker/requirements.txt`
- `docker build -t answers .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_b_68c500eb5c44832aaad7609a01e3f458