### PR TITLE
feat: Make model loader more robust and add tests

### DIFF
--- a/src/poker_ai/ai/model_loader.py
+++ b/src/poker_ai/ai/model_loader.py
@@ -21,15 +21,6 @@ def load_model_strategy(
     available, otherwise ``CPU``.
     """
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-    if not os.path.exists(model_path):
-        warnings.warn(
-            f"Model file not found at {model_path}. Falling back to RandomAIStrategy.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-        return RandomAIStrategy(), device
-
     config_path = os.path.splitext(model_path)[0] + ".config.json"
     try:
         with open(config_path) as f:
@@ -46,9 +37,17 @@ def load_model_strategy(
         state_dict = torch.load(model_path, map_location=device)
         model.load_state_dict(state_dict)
         return ModelAIStrategy(model, config, device), device
-    except Exception as exc:  # pragma: no cover - exercised in tests
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
         warnings.warn(
             f"Failed to load model from {model_path}: {exc}. Falling back to RandomAIStrategy.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return RandomAIStrategy(), device
+    except Exception as exc:  # pragma: no cover - unexpected error
+        warnings.warn(
+            f"Unexpected error loading model from {model_path}: {exc}. "
+            "Falling back to RandomAIStrategy.",
             RuntimeWarning,
             stacklevel=2,
         )

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -1,6 +1,7 @@
 import json
 import warnings
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -10,6 +11,14 @@ from poker_ai.ai.models.transformer import AdvantageNetwork
 from poker_ai.gui.playStrategy import ModelAIStrategy, PlayerStrategy, RandomAIStrategy
 
 
+@pytest.fixture
+def cpu_only() -> None:
+    """Mock ``torch.cuda.is_available`` to always return ``False``."""
+    with patch("torch.cuda.is_available", return_value=False):
+        yield
+
+
+@pytest.mark.usefixtures("cpu_only")
 @pytest.mark.parametrize("model_exists", [True, False])
 def test_load_model_strategy(tmp_path: Path, model_exists: bool) -> None:
     model_path = tmp_path / "cfr_model.pth"
@@ -42,5 +51,49 @@ def test_load_model_strategy(tmp_path: Path, model_exists: bool) -> None:
             strategy, device = load_model_strategy(str(model_path))
 
     assert isinstance(strategy, strategy_cls)
+    assert isinstance(device, torch.device)
+    assert device.type == "cpu"
+
+
+@pytest.mark.usefixtures("cpu_only")
+@pytest.mark.parametrize(
+    "config_writer, model_writer",
+    [
+        (None, torch.save),
+        (lambda path, data: path.write_text(json.dumps(data)), None),
+        (lambda path, data: path.write_text("invalid json"), torch.save),
+    ],
+)
+def test_load_model_strategy_fallback(
+    tmp_path: Path, config_writer, model_writer
+) -> None:
+    model_path = tmp_path / "cfr_model.pth"
+    config_path = model_path.with_suffix(".config.json")
+    config = {
+        "input_feature_dim": 18,
+        "hidden_dim": 16,
+        "num_heads": 2,
+        "num_layers": 1,
+        "num_actions": 4,
+    }
+    model = AdvantageNetwork(
+        history_feature_dim=config["input_feature_dim"],
+        card_feature_dim=config["input_feature_dim"],
+        hidden_dim=config["hidden_dim"],
+        num_heads=config["num_heads"],
+        num_layers=config["num_layers"],
+        num_actions=config["num_actions"],
+    )
+
+    if config_writer is not None:
+        config_writer(config_path, config)
+
+    if model_writer is not None:
+        model_writer(model.state_dict(), model_path)
+
+    with pytest.warns(RuntimeWarning):
+        strategy, device = load_model_strategy(str(model_path))
+
+    assert isinstance(strategy, RandomAIStrategy)
     assert isinstance(device, torch.device)
     assert device.type == "cpu"


### PR DESCRIPTION
This commit improves the robustness of the model loader by refactoring the `load_model_strategy` function to handle missing or corrupted model and configuration files more gracefully. The function now uses a `try...except` block to catch `FileNotFoundError` and `json.JSONDecodeError`, falling back to a `RandomAIStrategy` with a warning in these cases.

Additionally, this commit enhances the test suite for the model loader. It introduces a `cpu_only` fixture to ensure tests run on the CPU, and adds parametrized tests to cover various failure scenarios, such as a missing model file, a missing configuration file, or a corrupted configuration file.