### PR TITLE
Expose health and metrics endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,30 @@
-from fastapi import FastAPI
+"""Minimal FastAPI application exposing health and metrics endpoints."""
+
+from fastapi import FastAPI, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Info, generate_latest
 
 app = FastAPI()
 
 
+# Expose application metadata via Prometheus so tests can assert on it.
+APP_INFO = Info("app_info", "Application info")
+APP_INFO.info({"app": "texas_holdem_ai_gatc"})
+
+
 @app.get("/healthz")
 def healthz() -> dict[str, str]:
-    """Return a simple health indicator."""
+    """Return a simple liveness indicator."""
     return {"status": "ok"}
+
+
+@app.get("/readyz")
+def readyz() -> dict[str, str]:
+    """Return a simple readiness indicator."""
+    return {"status": "ok"}
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    """Expose Prometheus metrics for the application."""
+    data = generate_latest()
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,10 @@ description = "Texas Hold'em AI utilities (rules-safe side pots and hand evaluat
 requires-python = ">=3.10,<3.12"
 dependencies = [
     "eval7>=0.1.10",
+    "fastapi>=0.115",
     "numpy>=1.25",
     "pillow>=10.0",
+    "prometheus-client>=0.22",
     "pydantic>=2.7",
     "pyyaml>=6.0.1",
     "rich>=13.7",
@@ -31,6 +33,7 @@ dev = [
     "mypy>=1.10",
     "bandit>=1.7",
     "pre-commit>=3.7",
+    "httpx>=0.28",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ attrs==25.3.0
     # via hypothesis
 black==25.1.0
     # via texas-holdem-ai-gatc (pyproject.toml)
+certifi==2025.8.3
+    # via httpx
 cfgv==3.4.0
     # via pre-commit
 click==8.2.1
@@ -16,6 +18,8 @@ distlib==0.4.0
     # via virtualenv
 eval7==0.1.10
     # via texas-holdem-ai-gatc (pyproject.toml)
+fastapi==0.116.1
+    # via texas-holdem-ai-gatc (pyproject.toml)
 filelock==3.19.1
     # via
     #   torch
@@ -24,8 +28,16 @@ fsspec==2025.9.0
     # via torch
 future==1.0.0
     # via eval7
+h11==0.16.0
+    # via httpcore
+httpcore==1.0.9
+    # via httpx
+httpx==0.28.1
+    # via texas-holdem-ai-gatc (pyproject.toml)
 hypothesis==6.138.15
     # via texas-holdem-ai-gatc (pyproject.toml)
+idna==3.10
+    # via httpx
 identify==2.6.14
     # via pre-commit
 iniconfig==2.1.0
@@ -105,6 +117,8 @@ platformdirs==4.4.0
     #   virtualenv
 pluggy==1.6.0
     # via pytest
+prometheus-client==0.22.1
+    # via texas-holdem-ai-gatc (pyproject.toml)
 pre-commit==4.3.0
     # via texas-holdem-ai-gatc (pyproject.toml)
 pydantic==2.11.8

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,23 @@
+from fastapi.testclient import TestClient
+
+from app import app
+
+client = TestClient(app)
+
+
+def test_healthz() -> None:
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_readyz() -> None:
+    response = client.get("/readyz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_metrics_contains_app_info() -> None:
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "app_info" in response.text


### PR DESCRIPTION
## Summary
- add /readyz and /metrics endpoints with Prometheus export
- expose app metadata via `app_info` metric
- test health endpoints and metrics presence
- include fastapi, prometheus-client, and httpx dependencies

## Testing
- `ruff check app.py tests/test_health.py pyproject.toml`
- `pytest tests/test_health.py -vv`


------
https://chatgpt.com/codex/tasks/task_b_68c5046e36f8832aac59e9ea1b8005ce