### PR TITLE
Add hand-limited CLI play entry point and test

### DIFF
--- a/src/poker_ai/cli/play.py
+++ b/src/poker_ai/cli/play.py
@@ -29,6 +29,12 @@ def parse_args() -> argparse.Namespace:
         type=str,
         help="Path to saved AdvantageNetwork weights (.pth) to control AI players",
     )
+    parser.add_argument(
+        "--num-hands",
+        type=int,
+        default=1,
+        help="Number of hands to play before exiting (0 for infinite play)",
+    )
     return parser.parse_args()
 
 
@@ -120,11 +126,20 @@ def main() -> None:  # noqa: C901
     # Instantiate the game with chosen starting stack
     game = TexasHoldem(total_players, starting_stack, player_strategies)
 
-    # Play the game indefinitely
+    hands_to_play = args.num_hands
+    hands_played = 0
+
     try:
-        while True:
+        while hands_to_play == 0 or hands_played < hands_to_play:
             game.play_game()
+            if game.winner is not None:
+                print(f"Hand Summary: Player {game.winner + 1} wins!")
+            else:
+                print("Hand Summary: No winner determined.")
             print("\n--- Hand Completed ---")
+            hands_played += 1
+            if hands_to_play != 0 and hands_played >= hands_to_play:
+                break
             print("Resetting chips and starting a new hand.\n")
             game.reset_for_next_hand()
     except KeyboardInterrupt:

--- a/tests/test_cli_play.py
+++ b/tests/test_cli_play.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+src_path = os.path.join(project_root, "src")
+
+def test_cli_play_runs_banner(tmp_path: Path) -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "poker_ai.cli.play",
+        "--total-players",
+        "2",
+        "--num-humans",
+        "0",
+        "--num-hands",
+        "1",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [env.get("PYTHONPATH"), project_root, src_path])
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    assert result.returncode == 0
+    assert "Welcome to Texas Hold'em Poker Simulation" in result.stdout


### PR DESCRIPTION
## Summary
- add `--num-hands` option to `poker_ai.cli.play` so the human-vs-AI entry point can terminate after a set number of hands
- print a hand summary after each hand
- add regression test covering the CLI banner

## Testing
- `pytest tests/test_cli_play.py`


------
https://chatgpt.com/codex/tasks/task_b_68c5048c71dc832a8ebcb5d49efa597d