### PR TITLE
Add engine and rules tests and fix odd-chip payout

### DIFF
--- a/gatc_holdem/engine/rules.py
+++ b/gatc_holdem/engine/rules.py
@@ -106,7 +106,9 @@ def split_winnings_with_odd_chips(
     base = pot_amount // k
     remainder = pot_amount % k
     # Order winners starting from first seat left of the button
-    ordered = sorted(winners, key=lambda i: (i - dealer_index) % 1000000)
+    # Start from the seat immediately left of the button.  We subtract one
+    # before taking the modulo so that ``dealer_index + 1`` has key ``0``.
+    ordered = sorted(winners, key=lambda i: (i - dealer_index - 1) % 1000000)
     payout = {w: base for w in winners}
     for i in range(remainder):
         payout[ordered[i]] += 1

--- a/tests/engine/test_actions.py
+++ b/tests/engine/test_actions.py
@@ -1,0 +1,83 @@
+import os
+import sys
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+# add src to path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+for p in (PROJECT_ROOT, SRC_PATH):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from poker_ai.utils.action_mapping import get_legal_actions_mask  # noqa: E402
+
+
+@dataclass
+class DummyRules:
+    big_blind: int
+    player_chips: list[int]
+    bets: list[int]
+    current_bet: int
+    previous_raise_amount: int
+    pot: int
+
+
+@dataclass
+class DummyGame:
+    rules: DummyRules
+
+
+@pytest.mark.parametrize(
+    "rules, player, expected",
+    [
+        # No bet yet: fold, check, all-in bet legal
+        (
+            DummyRules(
+                big_blind=50,
+                player_chips=[1000, 1000],
+                bets=[0, 0],
+                current_bet=0,
+                previous_raise_amount=0,
+                pot=0,
+            ),
+            0,
+            {0, 1, 9},
+        ),
+        # Facing bet: fold, call and sufficiently large raises legal
+        (
+            DummyRules(
+                big_blind=50,
+                player_chips=[1000, 1000],
+                bets=[0, 100],
+                current_bet=100,
+                previous_raise_amount=100,
+                pot=150,
+            ),
+            0,
+            {0, 2, 5, 6, 7, 8, 9},
+        ),
+        # Short-stacked call all-in
+        (
+            DummyRules(
+                big_blind=50,
+                player_chips=[50, 1000],
+                bets=[0, 100],
+                current_bet=100,
+                previous_raise_amount=100,
+                pot=150,
+            ),
+            0,
+            {0, 2},
+        ),
+    ],
+)
+def test_legal_actions_match_stack_blinds_bets(
+    rules: DummyRules, player: int, expected: set[int]
+) -> None:
+    game = DummyGame(rules)
+    mask = get_legal_actions_mask(game, player, 10)
+    legal = {i for i, v in enumerate(mask.tolist()) if v}
+    assert legal == expected

--- a/tests/engine/test_deck.py
+++ b/tests/engine/test_deck.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import random
+from collections import Counter
+
+import numpy as np
+from scipy.stats import chisquare
+
+# ensure src is on path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+for p in (PROJECT_ROOT, SRC_PATH):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from poker_ai.engine.deck import Deck  # noqa: E402
+
+
+def test_no_duplicates() -> None:
+    deck = Deck()
+    deck.shuffle()
+    dealt = deck.deal(52)
+    assert len(dealt) == 52
+    assert len(set(dealt)) == 52
+
+
+def test_correct_counts_preflop_flop_turn_river() -> None:
+    deck = Deck()
+    deck.shuffle()
+    players = 4
+    preflop = []
+    for _ in range(players):
+        preflop.extend(deck.deal(2))
+    assert len(deck.cards) == 52 - players * 2
+    flop = deck.deal(3)
+    assert len(deck.cards) == 52 - players * 2 - 3
+    turn = deck.deal(1)
+    assert len(deck.cards) == 52 - players * 2 - 4
+    river = deck.deal(1)
+    assert len(deck.cards) == 52 - players * 2 - 5
+    # ensure all cards unique
+    all_cards = preflop + flop + turn + river
+    assert len(set(all_cards)) == len(all_cards)
+
+
+def test_shuffle_uniformity_chi2() -> None:
+    random.seed(0)
+    samples = 5200
+    first_cards = []
+    base_deck = Deck().cards
+    for _ in range(samples):
+        d = Deck()
+        d.shuffle()
+        first_cards.append(d.deal(1)[0])
+    counts = Counter(first_cards)
+    observed = np.array([counts.get(card, 0) for card in base_deck])
+    expected = np.full(len(base_deck), samples / len(base_deck))
+    chi2, p = chisquare(observed, expected)
+    assert p > 0.01

--- a/tests/engine/test_payouts.py
+++ b/tests/engine/test_payouts.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from collections import defaultdict
+
+# ensure src in path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+for p in (PROJECT_ROOT, SRC_PATH):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from gatc_holdem.engine.rules import build_side_pots, split_winnings_with_odd_chips  # noqa: E402
+
+
+def test_sidepots_multiway_allin() -> None:
+    contrib = [101, 201, 301]
+    in_hand = [True, True, True]
+    pots = build_side_pots(contrib, in_hand)
+    assert len(pots) == 2
+    assert pots[0].amount == 303 and set(pots[0].eligible) == {0, 1, 2}
+    assert pots[1].amount == 200 and set(pots[1].eligible) == {1, 2}
+    dealer = 0
+    payouts = defaultdict(int)
+    # main pot split between players 0 and 1 with odd chip to player 1
+    main_split = split_winnings_with_odd_chips(pots[0].amount, [0, 1], dealer)
+    for pid, amt in main_split.items():
+        payouts[pid] += amt
+    # side pot split between players 1 and 2
+    side_split = split_winnings_with_odd_chips(pots[1].amount, [1, 2], dealer)
+    for pid, amt in side_split.items():
+        payouts[pid] += amt
+    # return excess contribution from player 2
+    payouts[2] += contrib[2] - max(contrib[0], contrib[1])
+    assert payouts == {0: 151, 1: 252, 2: 200}
+    assert sum(payouts.values()) == sum(contrib)

--- a/tests/engine/test_terminal.py
+++ b/tests/engine/test_terminal.py
@@ -1,0 +1,46 @@
+import os
+import sys
+from typing import List
+
+# ensure src path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+for p in (PROJECT_ROOT, SRC_PATH):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from gatc_holdem.engine.rules import build_side_pots, split_winnings_with_odd_chips  # noqa: E402
+
+
+def settle(initial: List[int], contrib: List[int], in_hand: List[bool], winners: List[int]):
+    pots = build_side_pots(contrib, in_hand)
+    payouts = {i: 0 for i in range(len(initial))}
+    total = 0
+    for pot in pots:
+        total += pot.amount
+        eligible_winners = [w for w in winners if w in pot.eligible]
+        if eligible_winners:
+            split = split_winnings_with_odd_chips(pot.amount, eligible_winners, dealer_index=0)
+            for pid, amt in split.items():
+                payouts[pid] += amt
+    remaining = sum(contrib) - total
+    if remaining > 0:
+        active = [i for i, a in enumerate(in_hand) if a]
+        if len(active) == 1:
+            payouts[active[0]] += remaining
+    final = [initial[i] - contrib[i] + payouts[i] for i in range(len(initial))]
+    assert sum(final) == sum(initial)
+    assert all(ch >= 0 for ch in final)
+    return final
+
+
+def test_fold_call_showdown_payouts() -> None:
+    # dead blind / walk pot
+    final = settle([100, 100], [1, 2], [False, True], [1])
+    assert final == [99, 101]
+    # player calls and loses at showdown
+    final = settle([100, 100], [2, 2], [True, True], [0])
+    assert final == [102, 98]
+    # showdown tie
+    final = settle([100, 100], [50, 50], [True, True], [0, 1])
+    assert final == [100, 100]

--- a/tests/rules/test_hand_eval.py
+++ b/tests/rules/test_hand_eval.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import random
+import time
+
+import eval7
+
+# ensure src on path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+for p in (PROJECT_ROOT, SRC_PATH):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from gatc_poker.handeval import evaluate_hand  # noqa: E402
+
+
+def _random_hand() -> tuple[list[str], list[str]]:
+    ranks = list("23456789TJQKA")
+    suits = list("cdhs")
+    deck = [r + s for r in ranks for s in suits]
+    cards = random.sample(deck, 7)
+    return cards[:2], cards[2:]
+
+
+def test_rank_equivalence_vs_eval7() -> None:
+    random.seed(0)
+    iterations = 200_000
+    start = time.time()
+    for _ in range(iterations):
+        hole, board = _random_hand()
+        score1 = evaluate_hand(hole, board)
+        score2 = eval7.evaluate([eval7.Card(c) for c in hole + board])
+        assert score1 == score2
+    duration = time.time() - start
+    per100k = duration / iterations * 100_000
+    print(f"hand eval time per 100k: {per100k:.2f}s")
+
+
+def test_two_pair_kicker_ordering() -> None:
+    board = ["Ah", "Ac", "Kd", "7s", "2d"]
+    better = ["Kh", "Qh"]
+    worse = ["Kc", "Jh"]
+    assert evaluate_hand(better, board) > evaluate_hand(worse, board)
+    # identical kickers tie
+    tie1 = ["Kh", "Qh"]
+    tie2 = ["Kc", "Qd"]
+    assert evaluate_hand(tie1, board) == evaluate_hand(tie2, board)


### PR DESCRIPTION
## Summary
- add comprehensive engine tests for deck dealing, action legality, side-pot payouts, terminal settlements
- verify hand evaluation against eval7 over 200k random boards
- fix odd-chip distribution to start left of the dealer button

## Testing
- `pytest tests/engine/test_deck.py::test_no_duplicates tests/engine/test_deck.py::test_correct_counts_preflop_flop_turn_river tests/engine/test_deck.py::test_shuffle_uniformity_chi2 tests/engine/test_actions.py::test_legal_actions_match_stack_blinds_bets tests/engine/test_payouts.py::test_sidepots_multiway_allin tests/engine/test_terminal.py::test_fold_call_showdown_payouts tests/rules/test_hand_eval.py::test_rank_equivalence_vs_eval7 tests/rules/test_hand_eval.py::test_two_pair_kicker_ordering`


------
https://chatgpt.com/codex/tasks/task_b_68c52b3baa34832abae039f7e49d7929