### PR TITLE
Add CFR and Deep CFR math correctness tests

### DIFF
--- a/tests/cfr/test_avg_strategy.py
+++ b/tests/cfr/test_avg_strategy.py
@@ -1,0 +1,23 @@
+import torch
+
+from poker_ai.rules.cfr import update_strategy, compute_average_strategy
+
+
+def test_weighted_accumulation_vs_hand_counts():
+    weights = [1.0, 0.5, 0.25]
+    strategies = [
+        torch.tensor([0.5, 0.5]),
+        torch.tensor([0.2, 0.8]),
+        torch.tensor([0.1, 0.9]),
+    ]
+    cumulative = torch.zeros(2)
+    for w, strat in zip(weights, strategies):
+        cumulative = update_strategy(cumulative, strat * w)
+    avg = compute_average_strategy(cumulative)
+    manual = (
+        weights[0] * strategies[0]
+        + weights[1] * strategies[1]
+        + weights[2] * strategies[2]
+    ) / sum(weights)
+    assert torch.allclose(avg, manual)
+

--- a/tests/cfr/test_cfr_plus.py
+++ b/tests/cfr/test_cfr_plus.py
@@ -1,0 +1,38 @@
+import torch
+import pytest
+
+from poker_ai.rules.cfr import cfr_plus_iteration, discounted_cfr_plus_iteration
+
+
+class DummyGame:
+    def __init__(self, values: torch.Tensor):
+        self.values = values
+
+    def simulate_action(self, action: int) -> float:
+        return float(self.values[action])
+
+
+def test_regret_pruning_and_discounting():
+    num_actions = 2
+    game = DummyGame(torch.tensor([1.0, -1.0]))
+
+    # Start with positive regret on action 0 only
+    cum_regret = torch.tensor([1.0, 0.0])
+    cum_strategy = torch.zeros(num_actions)
+    cum_regret, cum_strategy = cfr_plus_iteration(
+        game, cum_regret, cum_strategy, num_actions, 1, prune_threshold=0.5
+    )
+    assert torch.all(cum_regret >= 0)
+    # Low-regret action should remain unchanged due to pruning
+    assert cum_regret[1] == pytest.approx(0.0)
+
+    # Test discounting semantics
+    cum_regret = torch.tensor([2.0, 0.0])
+    cum_strategy = torch.zeros(num_actions)
+    cum_regret, _ = discounted_cfr_plus_iteration(
+        game, cum_regret, cum_strategy, num_actions, 1, discount=0.5
+    )
+    assert torch.all(cum_regret >= 0)
+    # After discounting and update, cumulative regret should be half and clamped
+    assert torch.allclose(cum_regret, torch.tensor([1.0, 0.0]))
+

--- a/tests/cfr/test_counterfactual_values.py
+++ b/tests/cfr/test_counterfactual_values.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from poker_ai.rules.cfr import compute_regrets
+
+
+def test_node_values_match_handwritten_tree():
+    """CFVs and regrets should match manual computation on toy tree."""
+    # Toy tree: two actions; action values come from averaging chance outcomes
+    action_values = torch.tensor([0.0, 1.0])  # expected payoffs for actions A and B
+    strategy = torch.tensor([0.5, 0.5])
+    state_value = torch.sum(strategy * action_values)
+    assert state_value == pytest.approx(0.5)
+
+    regrets = compute_regrets(action_values, state_value)
+    assert torch.allclose(regrets, torch.tensor([-0.5, 0.5]))
+

--- a/tests/cfr/test_kuhn.py
+++ b/tests/cfr/test_kuhn.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pytest
+
+from poker_ai.games import KuhnTrainer, exploitability
+from poker_ai.utils.seeding import set_seed
+
+
+@pytest.fixture
+def canonical_kuhn_strategy() -> Dict[str, List[float]]:
+    """Canonical Kuhn Poker equilibrium strategy probabilities."""
+    return {
+        "1": [1.0, 0.0],
+        "2": [2 / 3, 1 / 3],
+        "3": [0.0, 1.0],
+        "1p": [1.0, 0.0],
+        "2p": [2 / 3, 1 / 3],
+        "3p": [0.0, 1.0],
+        "1b": [1.0, 0.0],
+        "2b": [2 / 3, 1 / 3],
+        "3b": [0.0, 1.0],
+        "1pb": [1.0, 0.0],
+        "2pb": [2 / 3, 1 / 3],
+        "3pb": [0.0, 1.0],
+    }
+
+
+def test_convergence(canonical_kuhn_strategy: Dict[str, List[float]]) -> None:
+    set_seed(0)
+    trainer = KuhnTrainer()
+    trainer.train(4000, seed=0)
+    strat = trainer.get_average_strategy()
+    exp = exploitability(strat)
+    # The simple trainer is approximate; ensure exploitability within a loose band
+    assert exp < 0.15
+    for infoset, probs in canonical_kuhn_strategy.items():
+        assert infoset in strat
+        if len(infoset) == 1:  # root information sets only
+            idx = 1 if probs[1] > probs[0] else 0
+            assert strat[infoset][idx] >= strat[infoset][1 - idx]

--- a/tests/cfr/test_regret_matching.py
+++ b/tests/cfr/test_regret_matching.py
@@ -1,0 +1,16 @@
+import torch
+
+from poker_ai.rules.cfr import calculate_strategy
+
+
+def test_simple_rps_update():
+    """Regret matching should reproduce textbook probabilities."""
+    # Positive regret on rock only -> deterministic rock
+    regrets = torch.tensor([1.0, -1.0, 0.0])
+    probs = calculate_strategy(regrets, 3)
+    assert torch.allclose(probs, torch.tensor([1.0, 0.0, 0.0]))
+
+    # All regrets non-positive -> uniform distribution
+    regrets = torch.tensor([-1.0, -2.0, -3.0])
+    probs = calculate_strategy(regrets, 3)
+    assert torch.allclose(probs, torch.ones(3) / 3)

--- a/tests/deepcfr/test_reservoirs.py
+++ b/tests/deepcfr/test_reservoirs.py
@@ -1,0 +1,35 @@
+import random
+import torch
+
+from poker_ai.ai.trainers.deep_cfr_trainer import DeepCFRTrainer, ReplayBuffer
+
+
+def test_perfect_reservoir_sampling():
+    random.seed(0)
+    buffer = ReplayBuffer(capacity=5)
+    for i in range(10):
+        s = torch.tensor([i], dtype=torch.float32)
+        r = torch.tensor([i], dtype=torch.float32)
+        buffer.push(s, r, i)
+    iterations = [exp[2] for exp in buffer.buffer]
+    assert sorted(iterations) == sorted([8, 1, 2, 5, 9])
+
+
+def test_minibatch_shapes_masks():
+    random.seed(0)
+    torch.manual_seed(0)
+    trainer = DeepCFRTrainer(input_feature_dim=4, hidden_dim=8, num_actions=2, buffer_capacity=50)
+    for i in range(20):
+        state = torch.ones(1, 4) * i
+        regret = torch.tensor([float(i), -float(i)])
+        trainer.replay_buffer.push(state, regret, i + 1)
+    initial_loss = trainer.train(batch_size=5)
+    for _ in range(5):
+        loss = trainer.train(batch_size=5)
+    assert loss <= initial_loss
+    batch = trainer.replay_buffer.sample(5)
+    states, regrets, iterations = zip(*batch, strict=False)
+    assert torch.stack(states).shape == (5, 1, 4)
+    assert torch.stack(regrets).shape == (5, 2)
+    assert torch.tensor(iterations).shape == (5,)
+


### PR DESCRIPTION
## Summary
- Add RPS regret-matching test
- Validate Kuhn Poker CFR convergence against canonical strategy directions
- Test counterfactual value computations on a toy tree
- Check CFR+ pruning and discounting semantics
- Verify Deep CFR reservoir sampling and minibatch shapes
- Ensure average strategy accumulation aligns with reach probabilities

## Testing
- `pytest tests/cfr/test_regret_matching.py tests/cfr/test_kuhn.py tests/cfr/test_counterfactual_values.py tests/cfr/test_cfr_plus.py tests/deepcfr/test_reservoirs.py tests/cfr/test_avg_strategy.py`


------
https://chatgpt.com/codex/tasks/task_b_68c52c63e570832aa8232d7531825428