### PR TITLE
Fix human strategy import for CLI play

### DIFF
--- a/src/poker_ai/ai/__init__.py
+++ b/src/poker_ai/ai/__init__.py
@@ -1,5 +1,15 @@
-"""AI utilities and model loading."""
+"""AI utilities and model loading.
 
-from .model_loader import load_model_strategy
+The heavy model-loading logic is imported lazily to avoid circular imports with
+GUI components.  ``load_model_strategy`` will only pull in the actual loader
+when called.
+"""
 
 __all__ = ["load_model_strategy"]
+
+
+def load_model_strategy(*args: object, **kwargs: object) -> object:
+    """Return an AI strategy loader with lazy imports."""  # pragma: no cover - thin wrapper
+    from .model_loader import load_model_strategy as _load
+
+    return _load(*args, **kwargs)

--- a/src/poker_ai/gui/playStrategy.py
+++ b/src/poker_ai/gui/playStrategy.py
@@ -98,9 +98,14 @@ class HumanStrategy(PlayerStrategy):
     def choose_action(self, game, player_index):  # noqa: C901
         # Display AI-derived GTO stats before prompting for action.
         # The import is delayed to keep GUI dependencies optional.
-        from ai_gto_analyzer import display_ai_gto_stats
+        # ``display_ai_gto_stats`` lives in the optional evaluation package and
+        # may be unavailable in lightweight environments.  Import through the
+        # package namespace so the function is ``None`` rather than raising a
+        # ``ModuleNotFoundError`` when the dependency tree is incomplete.
+        from poker_ai.evaluation import display_ai_gto_stats
 
-        display_ai_gto_stats(game, player_index)
+        if display_ai_gto_stats:
+            display_ai_gto_stats(game, player_index)
 
         while True:
             print(f"\n--- Player {player_index + 1}'s Turn ---")


### PR DESCRIPTION
## Summary
- avoid circular import by lazily loading AI model utilities
- guard optional GTO stats import in HumanStrategy

## Testing
- `python run_training.py --num-hands 1 --algorithm deep_cfr`
- `PYTHONPATH=src:. python -m poker_ai.cli.self_play --config src/poker_ai/config/config.yaml`
- `PYTHONPATH=src:. python test_gui_human_vs_ai.py`
- `PYTHONPATH=src:. python human_vs_ai.py --total-players 2 --num-humans 1 --starting-stack 1000 --num-hands 1`
- `PYTHONPATH=src:. python tests/test_performance_analysis.py`
- `PYTHONPATH=src:. pytest tests/test_cli_play.py`
- `ruff check src/poker_ai/gui/playStrategy.py src/poker_ai/ai/__init__.py`


------
https://chatgpt.com/codex/tasks/task_b_68c57210d4b0832abffcb8d886e232ca