### PR TITLE
Fix test runner imports and avoid strategy circular dependency

### DIFF
--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -9,10 +9,15 @@ import subprocess
 import sys
 import traceback
 
-# Add project root to path
+# Add project root and source directory to path
 project_root = os.path.abspath(os.path.dirname(__file__))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
+
+# Ensure the src directory is available for imports
+src_path = os.path.join(project_root, "src")
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
 
 
 def run_test_suite(test_name, test_command):

--- a/src/poker_ai/gui/playStrategy.py
+++ b/src/poker_ai/gui/playStrategy.py
@@ -4,10 +4,13 @@
 import random
 
 import torch
+from typing import TYPE_CHECKING
 
-from poker_ai.ai.models.transformer import AdvantageNetwork
 from poker_ai.utils.action_mapping import get_action_from_index, get_legal_actions_mask
 from poker_ai.utils.state_representation import prepare_transformer_input
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from poker_ai.ai.models.transformer import AdvantageNetwork
 
 # Import the new AI GTO display function lazily inside HumanStrategy to avoid
 # pulling heavy GUI dependencies when simply importing this module.
@@ -50,7 +53,13 @@ class RandomAIStrategy(PlayerStrategy):
 class ModelAIStrategy(PlayerStrategy):
     """Strategy driven by a trained :class:`AdvantageNetwork`."""
 
-    def __init__(self, model: AdvantageNetwork, config: dict, device: torch.device):
+    def __init__(self, model: "AdvantageNetwork", config: dict, device: torch.device):
+        # Import locally to avoid circular dependency during module import
+        from poker_ai.ai.models.transformer import AdvantageNetwork
+
+        if not isinstance(model, AdvantageNetwork):  # pragma: no cover - simple type check
+            raise TypeError("model must be an AdvantageNetwork instance")
+
         self.model = model.to(device)
         self.model.eval()
         self.config = config


### PR DESCRIPTION
## Summary
- ensure `run_all_tests.py` can import project modules by adding `src` to `sys.path`
- load `AdvantageNetwork` lazily in `playStrategy` to prevent circular imports

## Testing
- `python run_all_tests.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c5722d5f1c832aaa1531bc58009bcf