### PR TITLE
Add explicit GPU/NPU training flags

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,9 +52,10 @@ During training each hand uses a random number of players (between 2 and 10).
 
 To control the computation device you can use:
 
-- `--device cpu` to force CPU execution.
-- `--device npu` to target a single NPU.
-- `--npu` to utilize all available NPUs via `DataParallel`.
+- `--gpus` to train on available GPUs (uses all GPUs via `DataParallel`).
+- `--npus` to train on available NPUs (uses all NPUs via `DataParallel`).
+
+Omitting these flags runs training on the CPU by default.
 
 
 3. **Run tests**:
@@ -112,7 +113,7 @@ The directory `trained_models/` will be created automatically when saving.
 - Betting-tree abstraction utilities
 - Discounted CFR+ solver with regret discounting
 - Distributed self-play with multiprocessing
-- Optional GPU acceleration with automatic device selection
+- Optional GPU/NPU acceleration via command-line flags
 - Simple exploitability evaluation tools
 
 ## Using Distributed Self-Play

--- a/src/poker_ai/cli/train.py
+++ b/src/poker_ai/cli/train.py
@@ -42,18 +42,14 @@ def parse_args() -> argparse.Namespace:
         help="Path to configuration YAML file",
     )
     parser.add_argument(
-        "--device",
-        choices=["cpu", "cuda", "npu"],
-        default=None,
-        help=(
-            "Computation device. Defaults to CUDA if available, then CPU."
-            " Specify 'npu' or pass --npu to target NPUs."
-        ),
+        "--gpus",
+        action="store_true",
+        help="Use available GPUs. Wraps model in DataParallel if multiple GPUs are present.",
     )
     parser.add_argument(
-        "--npu",
+        "--npus",
         action="store_true",
-        help="Use all available NPUs via DataParallel (implies --device npu).",
+        help="Use available NPUs. Wraps model in DataParallel if multiple NPUs are present.",
     )
     return parser.parse_args()
 
@@ -70,9 +66,22 @@ def load_configuration(path: str | None = None) -> dict:
 
 
 def initialize_trainer(
-    algorithm: str, config: dict, device: str, use_all_npus: bool = False
+    algorithm: str, config: dict, device: str, use_data_parallel: bool = False
 ) -> object:
-    """Return a trainer instance based on selected algorithm."""
+    """Return a trainer instance based on selected algorithm.
+
+    Parameters
+    ----------
+    algorithm:
+        Which training algorithm to initialize.
+    config:
+        Loaded configuration dictionary.
+    device:
+        The computation device identifier (``cpu``, ``cuda`` or ``npu``).
+    use_data_parallel:
+        If ``True`` the underlying model will be wrapped with
+        :class:`torch.nn.DataParallel` to leverage multiple devices.
+    """
     trainer: object | None = None
     if algorithm == "ai_cfr":
         from poker_ai.ai.trainers.ai_cfr_trainer import AICFRTrainer
@@ -105,7 +114,7 @@ def initialize_trainer(
     else:
         raise ValueError(f"Unknown algorithm: {algorithm}")
 
-    if use_all_npus:
+    if use_data_parallel:
         model_to_wrap = None
         if hasattr(trainer, "advantage_net"):
             model_to_wrap = trainer.advantage_net
@@ -113,8 +122,7 @@ def initialize_trainer(
             model_to_wrap = trainer.model
 
         if model_to_wrap:
-            print("Wrapping model with DataParallel for multi-NPU training.")
-            # The model is already on the correct device from the trainer's __init__
+            print("Wrapping model with DataParallel for multi-device training.")
             wrapped_model = torch.nn.DataParallel(model_to_wrap)
             if hasattr(trainer, "advantage_net"):
                 trainer.advantage_net = wrapped_model
@@ -140,38 +148,44 @@ def main() -> None:  # noqa: C901
     ):
         if isinstance(getattr(args, attr, None), MagicMock):
             setattr(args, attr, None)
-    if isinstance(getattr(args, "npu", None), MagicMock):
-        args.npu = False
-    device: str = "cpu"
-    use_all_npus = False
+    for flag in ("gpus", "npus"):
+        if isinstance(getattr(args, flag, None), MagicMock):
+            setattr(args, flag, False)
 
-    if args.npu:
+    device: str = "cpu"
+    use_data_parallel = False
+
+    if args.gpus and args.npus:
+        raise ValueError("Cannot specify both --gpus and --npus.")
+
+    if args.npus:
         if hasattr(torch, "npu") and torch.npu.is_available():
             device = "npu"
             npu_count = torch.npu.device_count()
             if npu_count > 1:
-                use_all_npus = True
+                use_data_parallel = True
                 print(f"Multi-NPU training enabled. Found {npu_count} NPUs.")
             else:
-                print("NPU training enabled. Found 1 NPU.")
+                print("NPU training enabled.")
         else:
             print(
-                "Warning: --npu flag was specified, but no NPU devices are "
-                "available. Falling back to CPU."
+                "Warning: --npus specified, but no NPU devices are available. "
+                "Falling back to CPU."
             )
-    elif args.device:
-        device = args.device
-        if device == "npu":
-            if hasattr(torch, "npu") and torch.npu.is_available():
-                print("NPU training enabled.")
+    elif args.gpus:
+        if torch.cuda.is_available():
+            device = "cuda"
+            gpu_count = torch.cuda.device_count()
+            if gpu_count > 1:
+                use_data_parallel = True
+                print(f"Multi-GPU training enabled. Found {gpu_count} GPUs.")
             else:
-                print(
-                    "Warning: --device npu specified, but no NPU devices are "
-                    "available. Falling back to CPU."
-                )
-                device = "cpu"
-    elif torch.cuda.is_available():
-        device = "cuda"
+                print("GPU training enabled.")
+        else:
+            print(
+                "Warning: --gpus specified, but no GPU devices are available. "
+                "Falling back to CPU."
+            )
 
     # Load configuration
     config = load_configuration(args.config)
@@ -241,7 +255,9 @@ def main() -> None:  # noqa: C901
     try:
         cfr_trainer = cast(
             Any,
-            initialize_trainer(args.algorithm, config, device, use_all_npus=use_all_npus),
+            initialize_trainer(
+                args.algorithm, config, device, use_data_parallel=use_data_parallel
+            ),
         )
         print(f"{args.algorithm} trainer initialized.")
     except Exception as e:

--- a/tests/test_multi_npu.py
+++ b/tests/test_multi_npu.py
@@ -54,7 +54,10 @@ class TestMultiNPU(unittest.TestCase):
             for algorithm in algorithms:
                 with self.subTest(algorithm=algorithm):
                     trainer = initialize_trainer(
-                        algorithm=algorithm, config=dummy_config, device="npu", use_all_npus=True
+                        algorithm=algorithm,
+                        config=dummy_config,
+                        device="npu",
+                        use_data_parallel=True,
                     )
 
                     model_attr = "advantage_net" if algorithm == "deep_cfr" else "model"

--- a/tests/test_run_training.py
+++ b/tests/test_run_training.py
@@ -46,6 +46,8 @@ class TestRunTraining(unittest.TestCase):
         args_mock.algorithm = "ai_cfr"
         args_mock.config = "dummy_config.yaml"
         args_mock.device = None
+        args_mock.gpus = False
+        args_mock.npus = False
 
         training_params_mock = {
             "save_model_every_minutes": save_interval_minutes,
@@ -98,6 +100,8 @@ class TestRunTraining(unittest.TestCase):
         args_mock.algorithm = "ai_cfr"
         args_mock.config = "dummy_config.yaml"
         args_mock.device = None
+        args_mock.gpus = False
+        args_mock.npus = False
 
         training_params_mock = {
             "save_model_every_minutes": 0,
@@ -150,6 +154,8 @@ class TestRunTraining(unittest.TestCase):
         args_mock.algorithm = "ai_cfr"
         args_mock.config = "dummy_config.yaml"
         args_mock.device = None
+        args_mock.gpus = False
+        args_mock.npus = False
 
         training_params_mock = {
             "save_model_every_minutes": args_mock.save_minutes,
@@ -210,6 +216,8 @@ class TestRunTraining(unittest.TestCase):
         args_mock.algorithm = "ai_cfr"
         args_mock.config = "dummy_config.yaml"
         args_mock.device = None
+        args_mock.gpus = False
+        args_mock.npus = False
 
         # Simulate config loaded WITHOUT 'save_model_every_minutes' explicitly
         training_params_mock = {


### PR DESCRIPTION
## Summary
- Add `--gpus` and `--npus` flags to training CLI, defaulting to CPU
- Wrap models in `DataParallel` when multiple devices are detected
- Update docs and tests for new device-selection behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68c6351129b8832a9c5e424da3c654ee