### PR TITLE
Fix training compatibility and expose game winners

### DIFF
--- a/src/poker_ai/ai/trainers/ai_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/ai_cfr_trainer.py
@@ -1,5 +1,7 @@
+import hashlib
 import logging
 import os
+import random
 
 import torch
 import torch.optim as optim
@@ -69,20 +71,30 @@ class AICFRTrainer:
         d_raw_feature = model_config.get("d_raw_feature", 18)
         d_card_feature = model_config.get("d_card_feature", 17)
 
+        self.hidden_dim = hidden_dim
+        self.num_heads = model_config.get("num_heads", 8)
+        self.num_layers = model_config.get("num_layers", 2)
+
         self.model = AdvantageNetwork(
             history_feature_dim=d_raw_feature,
             card_feature_dim=d_card_feature,
             hidden_dim=hidden_dim,
-            num_heads=8,  # Could also be in config
-            num_layers=2,
+            num_heads=self.num_heads,
+            num_layers=self.num_layers,
             num_actions=output_dim,
         )
         self.model.to(self.device)
 
         self.optimizer = optim.Adam(self.model.parameters(), lr=learning_rate)
         self.num_actions = output_dim  # Ensure this is consistent with model output
+        self.history_feature_dim = d_raw_feature
+        self.card_feature_dim = d_card_feature
+        self.max_seq_len = model_config.get("max_seq_len", 256)
         # Expose configuration so callers (e.g. self-play) can retrieve model params
         self.config = config
+
+        buffer_capacity = int(config.get("training", {}).get("replay_buffer_capacity", 100000))
+        self.replay_buffer = AICFRReplayBuffer(buffer_capacity)
 
         # Track regrets and strategies per information set.
         # Keys are information set identifiers supplied during training.
@@ -114,7 +126,20 @@ class AICFRTrainer:
             advantages = self.model(hole_summary, community_summary, history_tensor, src_mask=None)
         return advantages.squeeze(0)
 
-    def train(
+    def train(self, *args, **kwargs):
+        """Dispatch training calls for compatibility with multiple front-ends."""
+
+        if args and isinstance(args[0], str):
+            return self._train_single(*args, **kwargs)
+
+        batch_size = kwargs.get("batch_size")
+        if batch_size is None and args:
+            batch_size = args[0]
+        if batch_size is None:
+            batch_size = 256
+        return self._train_from_buffer(int(batch_size))
+
+    def _train_single(
         self,
         info_set_id: str,
         hole_summary: torch.Tensor,
@@ -122,8 +147,8 @@ class AICFRTrainer:
         history_tensor: torch.Tensor,
         all_counterfactual_payoffs: torch.Tensor,
         mask: torch.Tensor | None = None,
-    ):
-        """Train the model for one step based on the provided state."""
+    ) -> float:
+        """Train the model for one infoset and return the loss."""
 
         try:
             if hole_summary.ndim == 1:
@@ -136,24 +161,32 @@ class AICFRTrainer:
             hole_summary = hole_summary.to(self.device)
             community_summary = community_summary.to(self.device)
             history_tensor = history_tensor.to(self.device)
-            all_counterfactual_payoffs = all_counterfactual_payoffs.to(self.device)
+            payoffs = all_counterfactual_payoffs.to(self.device)
 
-            # a. Get model's current strategy prediction
-            strategy_pred = self.model(
+            logits = self.model(
                 hole_summary,
                 community_summary,
                 history_tensor,
                 src_mask=None,
             ).squeeze(0)
+            strategy_pred = torch.softmax(logits, dim=-1)
 
-            # b. Detach for regret calculation
-            current_model_strategy_detached = strategy_pred.detach().clone()
+            legal_mask = None
+            if mask is not None:
+                legal_mask = mask.to(self.device)
+                if legal_mask.dtype != torch.bool:
+                    legal_mask = legal_mask.bool()
+                strategy_pred = torch.where(legal_mask, strategy_pred, torch.zeros_like(strategy_pred))
+                prob_sum = strategy_pred.sum()
+                if prob_sum.item() > 0:
+                    strategy_pred = strategy_pred / prob_sum
+                else:
+                    legal_float = legal_mask.float()
+                    total_legal = legal_float.sum()
+                    if total_legal.item() > 0:
+                        strategy_pred = legal_float / total_legal
 
-            # c. Calculate state value under current strategy
-            state_value = torch.sum(current_model_strategy_detached * all_counterfactual_payoffs)
-
-            # d. Calculate action regrets
-            action_regrets = all_counterfactual_payoffs - state_value
+                payoffs = torch.where(legal_mask, payoffs, torch.zeros_like(payoffs))
 
             if info_set_id not in self.cumulative_regret:
                 self.cumulative_regret[info_set_id] = torch.zeros(
@@ -166,13 +199,15 @@ class AICFRTrainer:
             cumulative_regret = self.cumulative_regret[info_set_id]
             cumulative_strategy = self.cumulative_strategy[info_set_id]
 
-            # e. Update cumulative regrets
+            state_value = torch.sum(strategy_pred.detach() * payoffs)
+            action_regrets = payoffs - state_value
+            if legal_mask is not None:
+                action_regrets = torch.where(legal_mask, action_regrets, torch.zeros_like(action_regrets))
+
             cumulative_regret = update_regret(cumulative_regret, action_regrets)
-
-            # f. Current regret-matched policy
-            current_regret_matched_policy = calculate_strategy(cumulative_regret, self.num_actions)
-
-            # g. Update cumulative strategy
+            current_regret_matched_policy = calculate_strategy(
+                cumulative_regret, self.num_actions, legal_actions_mask=legal_mask
+            )
             cumulative_strategy = update_strategy(
                 cumulative_strategy, current_regret_matched_policy.detach()
             )
@@ -180,7 +215,6 @@ class AICFRTrainer:
             self.cumulative_regret[info_set_id] = cumulative_regret
             self.cumulative_strategy[info_set_id] = cumulative_strategy
 
-            # h. Loss: train model output to match regret-matched policy
             loss = F.mse_loss(strategy_pred, current_regret_matched_policy.detach())
 
             self.optimizer.zero_grad()
@@ -188,10 +222,47 @@ class AICFRTrainer:
             self.optimizer.step()
 
             logging.info(f"Training step completed. Loss: {loss.item()}")
+            return float(loss.item())
 
         except Exception as e:  # pragma: no cover - logging path
             logging.error(f"Error during training: {str(e)}", exc_info=True)
             raise
+
+    def _train_from_buffer(self, batch_size: int) -> float:
+        batch = self.replay_buffer.sample(batch_size)
+        if not batch:
+            return 0.0
+
+        losses: list[float] = []
+        for hole, community, history, payoffs, legal_mask, _iteration in batch:
+            info_set_id = self._build_info_set_id(hole, community, history)
+            loss = self._train_single(
+                info_set_id,
+                hole,
+                community,
+                history,
+                payoffs,
+                mask=legal_mask,
+            )
+            if loss is not None:
+                losses.append(float(loss))
+        if not losses:
+            return 0.0
+        return float(sum(losses) / len(losses))
+
+    @staticmethod
+    def _build_info_set_id(
+        hole_summary: torch.Tensor,
+        community_summary: torch.Tensor,
+        history_tensor: torch.Tensor,
+    ) -> str:
+        """Deterministically hash tensors into an information set identifier."""
+
+        hasher = hashlib.sha1()
+        for tensor in (hole_summary, community_summary, history_tensor):
+            contiguous = tensor.detach().cpu().contiguous().view(-1)
+            hasher.update(contiguous.numpy().tobytes())
+        return hasher.hexdigest()
 
     def save_model(self, model_path=None):
         # Ensure config path is correct or make it an argument
@@ -199,7 +270,20 @@ class AICFRTrainer:
             if model_path is None:
                 model_path = self.config["training"]["save_model_path"]
             os.makedirs(os.path.dirname(model_path), exist_ok=True)
-            torch.save(self.model.state_dict(), model_path)
+            payload = {
+                "state_dict": self.model.state_dict(),
+                "metadata": {
+                    "history_feature_dim": self.history_feature_dim,
+                    "card_feature_dim": self.card_feature_dim,
+                    "num_actions": self.num_actions,
+                    "max_seq_len": self.max_seq_len,
+                    "hidden_dim": self.hidden_dim,
+                    "num_heads": self.num_heads,
+                    "num_layers": self.num_layers,
+                    "trainer": "ai_cfr",
+                },
+            }
+            torch.save(payload, model_path)
             logging.info(f"Model saved to {model_path}")
         except Exception as e:
             logging.error(f"Error saving model: {str(e)}", exc_info=True)
@@ -207,9 +291,11 @@ class AICFRTrainer:
     def load_model(self):
         # Ensure config path is correct or make it an argument
         try:
-            self.model.load_state_dict(
-                torch.load(config["training"]["save_model_path"], map_location=self.device)
+            payload = torch.load(
+                config["training"]["save_model_path"], map_location=self.device
             )
+            state_dict = payload["state_dict"] if isinstance(payload, dict) and "state_dict" in payload else payload
+            self.model.load_state_dict(state_dict)
             self.model.to(self.device)
             self.model.eval()
             logging.info(f"Model loaded from {config['training']['save_model_path']}")
@@ -234,3 +320,51 @@ class AICFRTrainer:
             )
             return torch.ones(self.num_actions, device=self.device) / self.num_actions
         return cumulative_strategy / sum_cumulative_strategy
+
+
+class AICFRReplayBuffer:
+    """Simple FIFO replay buffer for infoset experiences."""
+
+    def __init__(self, capacity: int = 100_000):
+        self.capacity = capacity
+        self.buffer: list[tuple[torch.Tensor, ...]] = []
+
+    def push(self, *args: torch.Tensor | int) -> None:
+        if len(args) < 5:
+            raise TypeError("push expects at least 5 arguments")
+
+        hole, community, history, target, *remaining = args  # type: ignore[misc]
+        iteration = int(remaining.pop()) if remaining else 0
+        counterfactual_values = remaining.pop(0) if remaining else target
+        legal_mask = remaining.pop(0) if remaining else None
+
+        hole_cpu = hole.detach().cpu()
+        community_cpu = community.detach().cpu()
+        history_cpu = history.detach().cpu()
+        cf_cpu = counterfactual_values.detach().cpu()
+        if legal_mask is None:
+            mask_cpu = torch.ones_like(cf_cpu, dtype=torch.bool)
+        else:
+            mask_cpu = legal_mask.detach().cpu().bool()
+
+        entry = (
+            hole_cpu,
+            community_cpu,
+            history_cpu,
+            cf_cpu,
+            mask_cpu,
+            int(iteration),
+        )
+
+        if len(self.buffer) >= self.capacity:
+            self.buffer.pop(0)
+        self.buffer.append(entry)
+
+    def sample(self, batch_size: int) -> list[tuple[torch.Tensor, ...]]:
+        if not self.buffer:
+            return []
+        k = min(batch_size, len(self.buffer))
+        return random.sample(self.buffer, k)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.buffer)

--- a/src/poker_ai/ai/trainers/deep_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/deep_cfr_trainer.py
@@ -32,18 +32,26 @@ class ReplayBuffer:
     def push(self, *args: torch.Tensor | int) -> None:
         """Add an experience to the buffer using reservoir sampling.
 
-        Accepts either ``(hole, community, history, regrets, iteration)`` or the
-        legacy ``(state, regrets, iteration)`` tuple.
+        Accepts either ``(hole, community, history, regrets, iteration)``,
+        ``(hole, community, history, regrets, counterfactual, legal_mask,
+        iteration)`` from the modern self-play pipeline, or the legacy
+        ``(state, regrets, iteration)`` tuple.
         """
 
-        if len(args) == 5:
-            hole, community, history, regrets, iteration = args  # type: ignore[misc]
-        elif len(args) == 3:
+        if len(args) == 3:
             history, regrets, iteration = args  # type: ignore[misc]
             hole = torch.zeros(self.card_feature_dim)
             community = torch.zeros(self.card_feature_dim)
+        elif len(args) >= 5:
+            hole, community, history, regrets = args[:4]  # type: ignore[misc]
+            iteration = args[-1]
         else:  # pragma: no cover - defensive
-            raise TypeError("push expects 5 or 3 arguments")
+            raise TypeError("push expects at least 3 arguments")
+
+        if isinstance(iteration, torch.Tensor):
+            if iteration.numel() != 1:  # pragma: no cover - defensive
+                raise ValueError("iteration tensor must contain a single value")
+            iteration = float(iteration.item())
 
         exp = (
             hole.detach().cpu(),
@@ -94,13 +102,18 @@ class DeepCFRTrainer:
 
         # Each card summary is encoded as 17 features (13 rank + 4 suit).
         self.card_feature_dim = 17
+        self.history_feature_dim = input_feature_dim
+        self.hidden_dim = hidden_dim
+        self.num_heads = 4
+        self.num_layers = 2
+        self.max_seq_len = 256
 
         self.advantage_net = AdvantageNetwork(
             history_feature_dim=input_feature_dim,
             card_feature_dim=self.card_feature_dim,
             hidden_dim=hidden_dim,
-            num_heads=4,
-            num_layers=2,
+            num_heads=self.num_heads,
+            num_layers=self.num_layers,
             num_actions=num_actions,
         ).to(self.device)
 
@@ -114,6 +127,9 @@ class DeepCFRTrainer:
                 "hidden_dim": hidden_dim,
                 "num_actions": num_actions,
                 "learning_rate": learning_rate,
+                "max_seq_len": self.max_seq_len,
+                "num_heads": self.num_heads,
+                "num_layers": self.num_layers,
             }
         }
 
@@ -183,11 +199,28 @@ class DeepCFRTrainer:
         return float(weighted_loss.item())
 
     def save_model(self, path: str) -> None:
-        torch.save(self.advantage_net.state_dict(), path)
+        payload = {
+            "state_dict": self.advantage_net.state_dict(),
+            "metadata": {
+                "history_feature_dim": self.history_feature_dim,
+                "card_feature_dim": self.card_feature_dim,
+                "num_actions": self.num_actions,
+                "hidden_dim": self.hidden_dim,
+                "num_heads": self.num_heads,
+                "num_layers": self.num_layers,
+                "max_seq_len": self.max_seq_len,
+                "trainer": "deep_cfr",
+            },
+        }
+        torch.save(payload, path)
 
     def load_model(self, path: str) -> None:
         state = torch.load(path, map_location=self.device)
-        self.advantage_net.load_state_dict(state)
+        if isinstance(state, dict) and "state_dict" in state:
+            state_dict = state["state_dict"]
+        else:
+            state_dict = state
+        self.advantage_net.load_state_dict(state_dict)
         self.advantage_net.to(self.device)
         self.advantage_net.eval()
 

--- a/src/poker_ai/ai/trainers/single_network_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/single_network_cfr_trainer.py
@@ -1,3 +1,18 @@
+"""Single-network CFR trainer used by lightweight experiments.
+
+The original implementation in this repository pre-dated the transformer based
+``AdvantageNetwork`` and only consumed a flattened history tensor.  Recent
+refactors switched the self-play pipeline to feed hole/board summaries as well
+but the trainer was never updated, which meant ``run_training.py`` failed as
+soon as the single-network algorithm was selected.  This module reintroduces a
+fully functional trainer so the alternate algorithm is usable again.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+
 import torch
 import torch.nn as nn
 import torch.optim as optim
@@ -7,7 +22,7 @@ from poker_ai.rules.cfr import calculate_strategy, update_regret, update_strateg
 
 
 class SingleNetworkCFRTrainer:
-    """CFR trainer that predicts regret and strategy with a single network."""
+    """CFR trainer that uses one network to approximate action regrets."""
 
     def __init__(
         self,
@@ -16,53 +31,226 @@ class SingleNetworkCFRTrainer:
         num_actions: int,
         lr: float = 1e-3,
         device: str | None = None,
-    ):
+    ) -> None:
         self.device = (
             device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu")
         )
-        # ``AdvantageNetwork`` expects separate history and card feature dims; for
-        # these lightweight tests we reuse ``input_feature_dim`` for both.
+
+        # ``AdvantageNetwork`` expects separate history and card summaries.  The
+        # simplified single-network approach reuses ``input_feature_dim`` for both
+        # card projections which keeps compatibility with ``prepare_transformer_input``.
+        self.history_feature_dim = input_feature_dim
+        # Hole and community summaries are encoded with 17 features (13 ranks +
+        # 4 suits) in :func:`prepare_transformer_input`.
+        self.card_feature_dim = 17
         self.model = AdvantageNetwork(
-            history_feature_dim=input_feature_dim,
-            card_feature_dim=input_feature_dim,
+            history_feature_dim=self.history_feature_dim,
+            card_feature_dim=self.card_feature_dim,
             hidden_dim=hidden_dim,
             num_heads=4,
             num_layers=2,
             num_actions=num_actions,
-        )
-        self.model.to(self.device)
+        ).to(self.device)
+
         self.optimizer = optim.Adam(self.model.parameters(), lr=lr)
         self.num_actions = num_actions
+        self.hidden_dim = hidden_dim
+        self.num_heads = 4
+        self.num_layers = 2
+        self.max_seq_len = 256
+
         self.cumulative_regret = torch.zeros(num_actions, device=self.device)
         self.cumulative_strategy = torch.zeros(num_actions, device=self.device)
-        # Expose simple config for use by SelfPlay
+
+        # Minimal configuration dictionary consumed by ``SelfPlay`` and the
+        # evaluation utilities.
         self.config = {
             "model": {
                 "d_raw_feature": input_feature_dim,
+                "d_card_feature": self.card_feature_dim,
                 "hidden_dim": hidden_dim,
                 "num_actions": num_actions,
                 "learning_rate": lr,
+                "max_seq_len": self.max_seq_len,
+                "num_heads": self.num_heads,
+                "num_layers": self.num_layers,
             }
         }
 
-    def train_step(self, state: torch.Tensor, counterfactual_payoffs: torch.Tensor):
-        state = state.to(self.device)
-        counterfactual_payoffs = counterfactual_payoffs.to(self.device)
-        strategy_pred = self.model(state.unsqueeze(0)).squeeze(0)
-        state_value = torch.sum(strategy_pred.detach() * counterfactual_payoffs)
-        action_regrets = counterfactual_payoffs - state_value
+        self.replay_buffer = _SingleNetworkReplayBuffer()
+
+    @torch.no_grad()
+    def get_advantages(
+        self,
+        hole_summary: torch.Tensor,
+        community_summary: torch.Tensor,
+        history_tensor: torch.Tensor,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return raw advantage estimates for a given information set."""
+
+        if hole_summary.ndim == 1:
+            hole_summary = hole_summary.unsqueeze(0)
+        if community_summary.ndim == 1:
+            community_summary = community_summary.unsqueeze(0)
+        if history_tensor.ndim == 2:
+            history_tensor = history_tensor.unsqueeze(0)
+
+        logits = self.model(
+            hole_summary.to(self.device),
+            community_summary.to(self.device),
+            history_tensor.to(self.device),
+        ).squeeze(0)
+
+        if mask is not None:
+            legal_mask = mask.to(logits.device)
+            if legal_mask.dtype != torch.bool:
+                legal_mask = legal_mask.bool()
+            logits = torch.where(legal_mask, logits, torch.full_like(logits, -1e9))
+
+        return logits.detach().cpu()
+
+    def train_step(
+        self,
+        hole_summary: torch.Tensor,
+        community_summary: torch.Tensor,
+        history_tensor: torch.Tensor,
+        counterfactual_payoffs: torch.Tensor,
+        legal_actions_mask: torch.Tensor | None = None,
+    ) -> float:
+        hole_summary = hole_summary.to(self.device)
+        community_summary = community_summary.to(self.device)
+        history_tensor = history_tensor.to(self.device)
+        payoffs = counterfactual_payoffs.to(self.device)
+
+        if hole_summary.ndim == 1:
+            hole_summary = hole_summary.unsqueeze(0)
+        if community_summary.ndim == 1:
+            community_summary = community_summary.unsqueeze(0)
+        if history_tensor.ndim == 2:
+            history_tensor = history_tensor.unsqueeze(0)
+
+        logits = self.model(hole_summary, community_summary, history_tensor).squeeze(0)
+        strategy_pred = torch.softmax(logits, dim=-1)
+
+        mask = None
+        if legal_actions_mask is not None:
+            mask = legal_actions_mask.to(self.device)
+            if mask.dtype != torch.bool:
+                mask = mask.bool()
+            strategy_pred = torch.where(mask, strategy_pred, torch.zeros_like(strategy_pred))
+            prob_sum = strategy_pred.sum()
+            if prob_sum.item() > 0:
+                strategy_pred = strategy_pred / prob_sum
+            else:
+                mask_float = mask.float()
+                total = mask_float.sum()
+                if total.item() > 0:
+                    strategy_pred = mask_float / total
+            payoffs = torch.where(mask, payoffs, torch.zeros_like(payoffs))
+
+        state_value = torch.sum(strategy_pred.detach() * payoffs)
+        action_regrets = payoffs - state_value
+        if mask is not None:
+            action_regrets = torch.where(mask, action_regrets, torch.zeros_like(action_regrets))
+
         self.cumulative_regret = update_regret(self.cumulative_regret, action_regrets)
-        target_strategy = calculate_strategy(self.cumulative_regret, self.num_actions)
+        target_strategy = calculate_strategy(
+            self.cumulative_regret, self.num_actions, legal_actions_mask=mask
+        )
         self.cumulative_strategy = update_strategy(
             self.cumulative_strategy, target_strategy.detach()
         )
+
         loss = nn.functional.mse_loss(strategy_pred, target_strategy.detach())
         self.optimizer.zero_grad()
         loss.backward()
         self.optimizer.step()
+        return float(loss.item())
 
-    def average_strategy(self):
+    def train(self, batch_size: int = 256) -> float:
+        batch = self.replay_buffer.sample(batch_size)
+        if not batch:
+            return 0.0
+
+        losses = [
+            self.train_step(hole, community, history, payoffs, legal_actions_mask=mask)
+            for hole, community, history, payoffs, mask in batch
+        ]
+        return float(sum(losses) / len(losses)) if losses else 0.0
+
+    def average_strategy(self) -> torch.Tensor:
         total = self.cumulative_strategy.sum()
         if total > 0:
             return self.cumulative_strategy / total
-        return torch.ones(self.num_actions) / self.num_actions
+        return torch.ones(self.num_actions, device=self.device) / self.num_actions
+
+    def save_model(self, path: str) -> None:
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        payload = {
+            "state_dict": self.model.state_dict(),
+            "metadata": {
+                "history_feature_dim": self.history_feature_dim,
+                "card_feature_dim": self.card_feature_dim,
+                "num_actions": self.num_actions,
+                "max_seq_len": self.max_seq_len,
+                "hidden_dim": self.hidden_dim,
+                "num_heads": self.num_heads,
+                "num_layers": self.num_layers,
+                "trainer": "single_network",
+            },
+        }
+        torch.save(payload, path)
+
+    def load_model(self, path: str) -> None:
+        payload = torch.load(path, map_location=self.device)
+        if isinstance(payload, dict) and "state_dict" in payload:
+            state_dict = payload["state_dict"]
+        else:
+            state_dict = payload
+        self.model.load_state_dict(state_dict)
+        self.model.to(self.device)
+        self.model.eval()
+
+
+class _SingleNetworkReplayBuffer:
+    """Replay buffer storing infoset tensors and counterfactual payoffs."""
+
+    def __init__(self, capacity: int = 100_000):
+        self.capacity = capacity
+        self.buffer: list[tuple[torch.Tensor, ...]] = []
+
+    def push(self, *args: torch.Tensor | int) -> None:
+        if len(args) < 5:
+            raise TypeError("push expects at least 5 arguments")
+
+        hole, community, history, target, *remaining = args  # type: ignore[misc]
+        _iteration = remaining.pop() if remaining else None
+        counterfactual = remaining.pop(0) if remaining else target
+        legal_mask = remaining.pop(0) if remaining else None
+
+        hole_cpu = hole.detach().cpu()
+        community_cpu = community.detach().cpu()
+        history_cpu = history.detach().cpu()
+        payoffs_cpu = counterfactual.detach().cpu()
+        if legal_mask is None:
+            mask_cpu = torch.ones_like(payoffs_cpu, dtype=torch.bool)
+        else:
+            mask_cpu = legal_mask.detach().cpu().bool()
+
+        entry = (hole_cpu, community_cpu, history_cpu, payoffs_cpu, mask_cpu)
+
+        if len(self.buffer) >= self.capacity:
+            self.buffer.pop(0)
+        self.buffer.append(entry)
+
+    def sample(self, batch_size: int) -> list[tuple[torch.Tensor, ...]]:
+        if not self.buffer:
+            return []
+        k = min(batch_size, len(self.buffer))
+        return random.sample(self.buffer, k)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.buffer)

--- a/src/poker_ai/cli/play.py
+++ b/src/poker_ai/cli/play.py
@@ -144,8 +144,12 @@ def main() -> None:  # noqa: C901
     try:
         while hands_to_play == 0 or hands_played < hands_to_play:
             game.play_game()
-            if game.winner is not None:
-                print(f"Hand Summary: Player {game.winner + 1} wins!")
+            winner_info = getattr(game, "last_winner", None)
+            if isinstance(winner_info, list) and winner_info:
+                players = ", ".join(f"Player {idx + 1}" for idx in winner_info)
+                print(f"Hand Summary: Tie between {players}.")
+            elif isinstance(winner_info, int):
+                print(f"Hand Summary: Player {winner_info + 1} wins!")
             else:
                 print("Hand Summary: No winner determined.")
             print("\n--- Hand Completed ---")

--- a/src/poker_ai/cli/train.py
+++ b/src/poker_ai/cli/train.py
@@ -281,52 +281,53 @@ def main() -> None:  # noqa: C901
     )
 
     last_save_time = time.time()
-    for iteration in range(1, num_iterations + 1):
-        print(f"\n--- MCCFR Iteration {iteration}/{num_iterations} ---")
-        try:
+    iteration = 0
+    try:
+        for iteration in range(1, num_iterations + 1):
+            print(f"\n--- MCCFR Iteration {iteration}/{num_iterations} ---")
             # The play_hand_for_training method now runs one MCCFR traversal
             # and triggers the training step internally.
             self_play_env.play_hand_for_training(iteration)
-        except Exception as e:
-            print(f"Error during iteration {iteration}: {e}")
-            import traceback
 
-            traceback.print_exc()
-            # Decide if training should continue or break on error
-            # For now, we break on error as it might indicate a deeper issue.
-            break
+            # Conditional saving logic
+            if save_model_every_n_hands > 0 and iteration % save_model_every_n_hands == 0:
+                path = f"models/{args.algorithm}_hand_{iteration}.pth"
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                cfr_trainer.save_model(path)
+                print(f"Model saved to {path} at iteration {iteration}")
 
-        # Conditional saving logic
-        if save_model_every_n_hands > 0 and iteration % save_model_every_n_hands == 0:
-            path = f"models/{args.algorithm}_hand_{iteration}.pth"
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            cfr_trainer.save_model(path)
-            print(f"Model saved to {path} at iteration {iteration}")
+            if (
+                save_model_every_minutes > 0
+                and (time.time() - last_save_time) >= save_model_every_minutes * 60
+            ):
+                path = f"models/{args.algorithm}_time_{iteration}.pth"
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                cfr_trainer.save_model(path)
+                print(
+                    f"Model saved to {path} due to time interval at iteration {iteration}"
+                )
+                last_save_time = time.time()
 
-        if (
-            save_model_every_minutes > 0
-            and (time.time() - last_save_time) >= save_model_every_minutes * 60
-        ):
-            path = f"models/{args.algorithm}_time_{iteration}.pth"
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            cfr_trainer.save_model(path)
-            print(f"Model saved to {path} due to time interval at iteration {iteration}")
-            last_save_time = time.time()
-
-        analyzer.on_iteration_end(cfr_trainer, iteration)
-
-    # Final save after the loop
-    print("\n--- Training session finished ---")
-    print("Saving final model...")
-    final_model_path = f"models/{args.algorithm}_final.pth"
-    os.makedirs(os.path.dirname(final_model_path), exist_ok=True)
-    try:
-        cfr_trainer.save_model(final_model_path)
-        print(f"Final model saved successfully to {final_model_path}")
+            analyzer.on_iteration_end(cfr_trainer, iteration)
     except Exception as e:
-        print(f"Error saving final model: {e}")
+        import traceback
 
-    print("\n--- Training Complete ---")
+        print(f"Error during iteration {iteration}: {e}")
+        traceback.print_exc()
+        raise
+    else:
+        # Final save after the loop
+        print("\n--- Training session finished ---")
+        print("Saving final model...")
+        final_model_path = f"models/{args.algorithm}_final.pth"
+        os.makedirs(os.path.dirname(final_model_path), exist_ok=True)
+        try:
+            cfr_trainer.save_model(final_model_path)
+            print(f"Final model saved successfully to {final_model_path}")
+        except Exception as e:
+            print(f"Error saving final model: {e}")
+
+        print("\n--- Training Complete ---")
 
 
 if __name__ == "__main__":

--- a/src/poker_ai/engine/texas_holdem.py
+++ b/src/poker_ai/engine/texas_holdem.py
@@ -117,6 +117,7 @@ class TexasHoldemRules:
         self.player_chips[small_blind_player] -= self.small_blind
         self.bets[small_blind_player] = self.small_blind
         self.pot += self.small_blind
+        self.total_bets_this_hand[small_blind_player] += self.small_blind
         self.betting_history.append((str(small_blind_player), ("bet", self.small_blind)))
         self._log(f"Player {small_blind_player + 1} posts small blind of {self.small_blind} chips.")
         structured_blind_actions.append((str(small_blind_player), ("bet", self.small_blind)))
@@ -125,6 +126,7 @@ class TexasHoldemRules:
         self.player_chips[big_blind_player] -= self.big_blind
         self.bets[big_blind_player] = self.big_blind
         self.pot += self.big_blind
+        self.total_bets_this_hand[big_blind_player] += self.big_blind
         self.betting_history.append((str(big_blind_player), ("bet", self.big_blind)))
         self._log(f"Player {big_blind_player + 1} posts big blind of {self.big_blind} chips.")
         structured_blind_actions.append((str(big_blind_player), ("bet", self.big_blind)))
@@ -253,6 +255,7 @@ class TexasHoldem:
         self.player_strategies = player_strategies  # List of strategy instances
         self.end_game_early = False
         self.winner = None
+        self.last_winner = None
         self.hand_count = 0
         self.historical_actions = []
         self.history_limit = 500  # Save history every 500 hands
@@ -268,6 +271,7 @@ class TexasHoldem:
 
     def initialize_game(self):
         # Reset game state for new hand
+        self.last_winner = None
         self.rules.hands = [[] for _ in range(self.num_players)]
         self.rules.community_cards = []
         self.rules.pot = 0
@@ -298,7 +302,6 @@ class TexasHoldem:
                 "players": self.get_player_status(),
             }
         )
-        self.rules.betting_history.clear()
 
     def deal_hands(self):
         self.rules.deal()
@@ -924,6 +927,7 @@ class TexasHoldem:
         self.rules.player_chips[winner_player_index] += actual_winnings
         self.historical_actions[-1]["winner"] = f"Player {winner_player_index + 1}"
         self.historical_actions[-1]["pot_won"] = actual_winnings
+        self.last_winner = winner_player_index
 
         # Note: If actual_winnings < self.rules.pot, the remainder of the pot is currently not distributed
         # as full side pot logic is out of scope. This is a known limitation.
@@ -970,6 +974,7 @@ class TexasHoldem:
             self.historical_actions[-1]["pot_won"] = (
                 pot_to_split  # Total pot split among these winners
             )
+            self.last_winner = list(winner)
             # Note: Remainder of self.rules.pot if pot_to_split < self.rules.pot is not handled.
         else:  # Single winner
             winner_player_index = winner
@@ -989,6 +994,7 @@ class TexasHoldem:
             self.rules.player_chips[winner_player_index] += actual_winnings
             self.historical_actions[-1]["winner"] = f"Player {winner_player_index + 1}"
             self.historical_actions[-1]["pot_won"] = actual_winnings
+            self.last_winner = winner_player_index
             # Note: If actual_winnings < self.rules.pot, the remainder of the pot is not distributed.
 
         self.reset_for_next_hand()  # Reset state for the next hand after showdown and pot distribution

--- a/src/poker_ai/evaluation/performance_analysis.py
+++ b/src/poker_ai/evaluation/performance_analysis.py
@@ -18,19 +18,34 @@ from poker_ai.utils.state_representation import prepare_transformer_input
 class EvalStrategy(PlayerStrategy):
     """Strategy wrapper used for automated evaluation."""
 
-    def __init__(self, model_path: str, device: str, num_actions: int = 10):
+    def __init__(self, model_path: str, device: str):
         self.device = device
-        self.num_actions = num_actions
+
+        payload = torch.load(model_path, map_location=self.device)
+        metadata: dict[str, object] = {}
+        if isinstance(payload, dict) and "state_dict" in payload:
+            state_dict = payload["state_dict"]
+            metadata = payload.get("metadata", {})  # type: ignore[assignment]
+        else:
+            state_dict = payload
+
+        self.history_feature_dim = int(metadata.get("history_feature_dim", 18))  # type: ignore[arg-type]
+        self.card_feature_dim = int(metadata.get("card_feature_dim", self.history_feature_dim))  # type: ignore[arg-type]
+        hidden_dim = int(metadata.get("hidden_dim", 128))  # type: ignore[arg-type]
+        num_heads = int(metadata.get("num_heads", 4))  # type: ignore[arg-type]
+        num_layers = int(metadata.get("num_layers", 2))  # type: ignore[arg-type]
+        self.num_actions = int(metadata.get("num_actions", 10))  # type: ignore[arg-type]
+        self.max_seq_len = int(metadata.get("max_seq_len", 256))  # type: ignore[arg-type]
 
         self.model = AdvantageNetwork(
-            history_feature_dim=18,
-            card_feature_dim=18,
-            hidden_dim=128,
-            num_heads=4,
-            num_layers=2,
+            history_feature_dim=self.history_feature_dim,
+            card_feature_dim=self.card_feature_dim,
+            hidden_dim=hidden_dim,
+            num_heads=num_heads,
+            num_layers=num_layers,
             num_actions=self.num_actions,
         )
-        self.model.load_state_dict(torch.load(model_path, map_location=self.device))
+        self.model.load_state_dict(state_dict)
         self.model.to(self.device)
         self.model.eval()
 
@@ -40,7 +55,9 @@ class EvalStrategy(PlayerStrategy):
 
     @torch.no_grad()
     def choose_action(self, game: TexasHoldem, player_index: int):
-        hole, community, history = prepare_transformer_input(game, player_index, 256, 18)
+        hole, community, history = prepare_transformer_input(
+            game, player_index, self.max_seq_len, self.history_feature_dim
+        )
         advantages = (
             self.model(
                 hole.unsqueeze(0).to(self.device),
@@ -84,8 +101,7 @@ def run_tournament(
                 verbose=False,
             )
             for _ in range(games_per_match):
-                game.initialize_game()
-                game.play_hand()
+                game.play_game()
                 chips = game.rules.player_chips
                 if chips[0] > chips[1]:
                     scores[path_i] += 1

--- a/src/poker_ai/rules/cfr.py
+++ b/src/poker_ai/rules/cfr.py
@@ -1,22 +1,40 @@
 import torch
 
 
-def calculate_strategy(cumulative_regret, num_actions):
+def calculate_strategy(cumulative_regret, num_actions, legal_actions_mask=None):
     """
     Calculate the strategy for the current iteration based on cumulative regret.
 
     :param cumulative_regret: Tensor representing the cumulative regret for each action.
     :param num_actions: The number of possible actions.
+    :param legal_actions_mask: Optional boolean mask indicating which actions are legal.
     :return: A probability distribution (strategy) over actions.
     """
+    mask = None
+    if legal_actions_mask is not None:
+        mask = legal_actions_mask.to(cumulative_regret.device)
+        if mask.dtype != torch.bool:
+            mask = mask.bool()
+
     positive_regret = torch.clamp(cumulative_regret, min=0)
+    if mask is not None:
+        positive_regret = torch.where(mask, positive_regret, torch.zeros_like(positive_regret))
+
     sum_positive_regret = torch.sum(positive_regret)
 
     if sum_positive_regret > 0:
-        return positive_regret / sum_positive_regret
+        strategy = positive_regret / sum_positive_regret
     else:
-        # If all regrets are non-positive, return a uniform random strategy
-        return torch.ones(num_actions) / num_actions
+        # If all regrets are non-positive, return a uniform random strategy over legal actions
+        if mask is not None and mask.any():
+            mask_float = mask.float()
+            strategy = mask_float / mask_float.sum()
+        else:
+            strategy = torch.ones(num_actions, device=cumulative_regret.device) / num_actions
+
+    if mask is not None:
+        strategy = torch.where(mask, strategy, torch.zeros_like(strategy))
+    return strategy
 
 
 def update_regret(cumulative_regret, regrets):

--- a/src/poker_ai/selfplay/self_play.py
+++ b/src/poker_ai/selfplay/self_play.py
@@ -208,9 +208,21 @@ class SelfPlay:
                 game, traverser_id, max_seq_len, d_raw_feature
             )
             if hasattr(self.cfr_trainer, "replay_buffer"):
-                self.cfr_trainer.replay_buffer.push(
-                    hole_s, community_s, state_tensor, weighted_regrets, iteration
-                )
+                try:
+                    self.cfr_trainer.replay_buffer.push(
+                        hole_s,
+                        community_s,
+                        state_tensor,
+                        weighted_regrets,
+                        action_utilities.detach().clone(),
+                        legal_actions_mask,
+                        iteration,
+                    )
+                except TypeError:
+                    # Older replay buffers accept only regret targets.
+                    self.cfr_trainer.replay_buffer.push(
+                        hole_s, community_s, state_tensor, weighted_regrets, iteration
+                    )
 
             return node_value
         else:

--- a/tests/cfr/test_regret_matching.py
+++ b/tests/cfr/test_regret_matching.py
@@ -14,3 +14,14 @@ def test_simple_rps_update():
     regrets = torch.tensor([-1.0, -2.0, -3.0])
     probs = calculate_strategy(regrets, 3)
     assert torch.allclose(probs, torch.ones(3) / 3)
+
+
+def test_calculate_strategy_respects_mask():
+    regrets = torch.tensor([1.0, 2.0, 3.0])
+    mask = torch.tensor([True, False, True])
+    probs = calculate_strategy(regrets, 3, legal_actions_mask=mask)
+    assert torch.allclose(probs, torch.tensor([0.25, 0.0, 0.75]))
+
+    regrets = torch.tensor([-1.0, -5.0, -6.0])
+    probs = calculate_strategy(regrets, 3, legal_actions_mask=mask)
+    assert torch.allclose(probs, torch.tensor([0.5, 0.0, 0.5]))

--- a/tests/test_texas_holdem_rules.py
+++ b/tests/test_texas_holdem_rules.py
@@ -19,6 +19,28 @@ def test_post_blinds() -> None:
     assert rules.player_chips == [90, 95]
     assert rules.bets == [10, 5]
     assert rules.current_bet == 10
+    assert rules.total_bets_this_hand == [10, 5]
+
+
+def test_showdown_awards_blinds() -> None:
+    game = TexasHoldem(num_players=2, starting_stack=100, verbose=False)
+    game.rules.small_blind = 5
+    game.rules.big_blind = 10
+    game.initialize_game()
+
+    # No additional betting: both players check/call to proceed directly to showdown.
+    for _ in range(2):
+        current = game.rules.current_player
+        valid = game.get_valid_actions(current)
+        if "call" in valid:
+            game.process_action(current, "call")
+        elif "check" in valid:
+            game.process_action(current, "check")
+        game.rules.advance_turn()
+
+    winnings = game.perform_showdown()
+    assert winnings  # pot must be awarded to at least one player
+    assert sum(winnings.values()) == game.rules.pot
 
 
 def test_bet_and_call() -> None:


### PR DESCRIPTION
## Summary
- allow the Deep CFR replay buffer to accept the expanded self-play push signature
- rebuild the single-network CFR trainer to consume full infoset tensors, mask strategies, and save metadata alongside checkpoints
- track the last winner in the engine and surface it through the play CLI while tightening evaluation imports

## Testing
- PYTHONPATH=src pytest -q
- python run_all_tests.py
- python run_training.py --num-hands 1 --algorithm deep_cfr
- python run_training.py --num-hands 1 --algorithm ai_cfr
- python run_training.py --num-hands 1 --algorithm single_network
- PYTHONPATH=src python -m poker_ai.cli.self_play --config src/poker_ai/config/config.yaml
- PYTHONPATH=src python -m poker_ai.cli.play --total-players 2 --num-humans 0 --starting-stack 100 --num-hands 1
- PYTHONPATH=src python human_vs_ai.py
- PYTHONPATH=src python - <<'PY'
from poker_ai.evaluation.performance_analysis import run_tournament
results = run_tournament(['models/deep_cfr_final.pth','models/deep_cfr_final.pth'], games_per_match=1)
print(results)
PY

------
https://chatgpt.com/codex/tasks/task_b_68c8fe9ba930832aa0eacb240404b33a