### PR TITLE
Handle disabled performance analyzer interval

### DIFF
--- a/src/poker_ai/evaluation/performance_analysis.py
+++ b/src/poker_ai/evaluation/performance_analysis.py
@@ -116,13 +116,15 @@ class ModelPerformanceAnalyzer:
     def __init__(
         self,
         models_dir: str = "models",
-        save_every_samples: int = 100000,
+        save_every_samples: int | None = 100000,
         tournament_threshold: int = 10,
         tournament_size: int = 10,
         games_per_match: int = 10,
         device: str = "cpu",
     ):
         self.models_dir = models_dir
+        if save_every_samples is not None and save_every_samples <= 0:
+            save_every_samples = None
         self.save_every_samples = save_every_samples
         self.tournament_threshold = tournament_threshold
         self.tournament_size = tournament_size
@@ -130,6 +132,8 @@ class ModelPerformanceAnalyzer:
         self.device = device
 
     def on_iteration_end(self, trainer, sample_count: int) -> None:
+        if self.save_every_samples is None:
+            return
         if sample_count % self.save_every_samples != 0:
             return
         os.makedirs(self.models_dir, exist_ok=True)

--- a/tests/test_performance_analysis.py
+++ b/tests/test_performance_analysis.py
@@ -53,6 +53,17 @@ class TestPerformanceAnalyzer(unittest.TestCase):
                 self.assertEqual(len(os.listdir(tmpdir)), 2)
                 mock_tourn.assert_called_once()
 
+    def test_disabled_when_zero_interval(self):
+        trainer = DummyTrainer()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            analyzer = ModelPerformanceAnalyzer(
+                models_dir=tmpdir,
+                save_every_samples=0,
+                device="cpu",
+            )
+            analyzer.on_iteration_end(trainer, 1)
+            self.assertEqual(os.listdir(tmpdir), [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- treat non-positive save intervals as disabled in ModelPerformanceAnalyzer to avoid division-by-zero errors
- add regression test verifying that a zero sample interval skips saving

## Testing
- pytest -q tests/test_performance_analysis.py
- PYTHONPATH=src python -m poker_ai.cli.train --num-hands 1 --algorithm ai_cfr --save-model-every 0 --save-samples 0

------
https://chatgpt.com/codex/tasks/task_b_68c91ae38490832a9e88894021643df6