### PR TITLE
Refactor model loading to use embedded metadata

### DIFF
--- a/src/poker_ai/ai/model_loader.py
+++ b/src/poker_ai/ai/model_loader.py
@@ -1,8 +1,7 @@
-import json
-import os
 import warnings
 
 import torch
+from collections.abc import Mapping
 
 from poker_ai.ai.models.transformer import AdvantageNetwork
 from poker_ai.gui.playStrategy import ModelAIStrategy, PlayerStrategy, RandomAIStrategy
@@ -15,29 +14,61 @@ def load_model_strategy(
 ) -> tuple[PlayerStrategy, torch.device]:
     """Load an AI strategy from ``model_path``.
 
-    If the model file or its companion ``.config.json`` file is missing or
-    fails to load, a :class:`RandomAIStrategy` is returned instead and a
-    ``RuntimeWarning`` is emitted. The model is loaded onto ``CUDA`` when
-    available, otherwise ``CPU``.
+    If the model file is missing or fails to load, a :class:`RandomAIStrategy`
+    is returned instead and a ``RuntimeWarning`` is emitted. The model is
+    loaded onto ``CUDA`` when available, otherwise ``CPU``.
     """
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    config_path = os.path.splitext(model_path)[0] + ".config.json"
     try:
-        with open(config_path) as f:
-            config = json.load(f)
+        payload = torch.load(model_path, map_location=device)
+
+        if not isinstance(payload, Mapping):
+            raise ValueError("Model payload missing metadata")
+
+        metadata_obj = payload.get("metadata")
+        if not isinstance(metadata_obj, Mapping):
+            raise ValueError("Model metadata missing or malformed")
+
+        try:
+            history_feature_dim = int(metadata_obj["history_feature_dim"])
+            card_feature_dim = int(metadata_obj["card_feature_dim"])
+            num_actions = int(metadata_obj["num_actions"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid model metadata: {exc}") from exc
+
+        hidden_dim = int(metadata_obj.get("hidden_dim", 128))
+        num_heads = int(metadata_obj.get("num_heads", 4))
+        num_layers = int(metadata_obj.get("num_layers", 2))
+        max_seq_len = int(metadata_obj.get("max_seq_len", 256))
+
+        state_dict = payload.get("state_dict")
+        if not isinstance(state_dict, Mapping):
+            raise ValueError("Model payload missing state_dict")
 
         model = AdvantageNetwork(
-            history_feature_dim=config["input_feature_dim"],
-            card_feature_dim=config["input_feature_dim"],
-            hidden_dim=config["hidden_dim"],
-            num_heads=config["num_heads"],
-            num_layers=config["num_layers"],
-            num_actions=config["num_actions"],
+            history_feature_dim=history_feature_dim,
+            card_feature_dim=card_feature_dim,
+            hidden_dim=hidden_dim,
+            num_heads=num_heads,
+            num_layers=num_layers,
+            num_actions=num_actions,
         )
-        state_dict = torch.load(model_path, map_location=device)
+
         model.load_state_dict(state_dict)
+
+        config = dict(metadata_obj)
+        config["history_feature_dim"] = history_feature_dim
+        config["card_feature_dim"] = card_feature_dim
+        config["hidden_dim"] = hidden_dim
+        config["num_heads"] = num_heads
+        config["num_layers"] = num_layers
+        config["num_actions"] = num_actions
+        config["max_seq_len"] = max_seq_len
+        config.setdefault("input_feature_dim", history_feature_dim)
+        config.setdefault("d_raw_feature", history_feature_dim)
+
         return ModelAIStrategy(model, config, device), device
-    except (FileNotFoundError, json.JSONDecodeError) as exc:
+    except (FileNotFoundError, ValueError) as exc:
         warnings.warn(
             f"Failed to load model from {model_path}: {exc}. Falling back to RandomAIStrategy.",
             RuntimeWarning,

--- a/src/poker_ai/cli/play.py
+++ b/src/poker_ai/cli/play.py
@@ -3,14 +3,10 @@
 """Command line game allowing humans to play against simple AI players."""
 
 import argparse
-import json
-import os
 import sys
 from typing import Any, cast
 
-import torch
-
-from poker_ai.ai.models.transformer import AdvantageNetwork
+from poker_ai.ai import load_model_strategy
 from poker_ai.config import load_config
 from poker_ai.engine.texas_holdem import TexasHoldem
 from poker_ai.gui.playStrategy import (
@@ -44,24 +40,13 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_model(model_path: str) -> ModelAIStrategy:
-    """Load a saved :class:`AdvantageNetwork` and wrap it in ``ModelAIStrategy``."""
-    config_path = os.path.splitext(model_path)[0] + ".config.json"
-    with open(config_path) as f:
-        model_config = json.load(f)
+def load_model(model_path: str) -> ModelAIStrategy | None:
+    """Load a saved AI model using :func:`load_model_strategy`."""
 
-    network_params = {
-        "history_feature_dim": model_config["input_feature_dim"],
-        "card_feature_dim": model_config["input_feature_dim"],
-        "hidden_dim": model_config["hidden_dim"],
-        "num_heads": model_config["num_heads"],
-        "num_layers": model_config["num_layers"],
-        "num_actions": model_config["num_actions"],
-    }
-    model = AdvantageNetwork(**network_params)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model.load_state_dict(torch.load(model_path, map_location=device))
-    return ModelAIStrategy(model, model_config, device)
+    strategy, _ = load_model_strategy(model_path)
+    if isinstance(strategy, ModelAIStrategy):
+        return strategy
+    return None
 
 
 def main() -> None:  # noqa: C901

--- a/src/poker_ai/cli/self_play.py
+++ b/src/poker_ai/cli/self_play.py
@@ -7,6 +7,7 @@ import signal
 import sys
 import threading
 import time
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, cast
 
@@ -84,47 +85,43 @@ def parse_args():
 
 def load_transformer_model(cfg):
     model_name = cfg.get("model", {}).get("name", "texas_holdem_transformer_ai")
-    weights_path, config_path = get_model_paths(model_name)
+    weights_path = get_model_path(model_name)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    if model_exists(weights_path, config_path):
-        strategy = load_existing_model(weights_path, config_path, device)
-        last_mtime = os.path.getmtime(weights_path)
-        return strategy, weights_path, last_mtime
+    if os.path.exists(weights_path):
+        try:
+            strategy = load_existing_model(weights_path, device)
+            last_mtime = os.path.getmtime(weights_path)
+            return strategy, weights_path, last_mtime
+        except Exception as exc:  # pragma: no cover - defensive logging
+            print(f"Failed to load existing model: {exc}. Initializing a new model.")
     strategy = initialize_new_model(device)
     return strategy, weights_path, None
 
 
-def get_model_paths(model_name):
-    weights_path = os.path.join(config.MODEL_DIR, f"{model_name}.pth")
-    config_path = os.path.join(config.MODEL_DIR, f"{model_name}_config.json")
-    return weights_path, config_path
+def get_model_path(model_name):
+    return os.path.join(config.MODEL_DIR, f"{model_name}.pth")
 
 
-def model_exists(weights_path, config_path):
-    return os.path.exists(weights_path) and os.path.exists(config_path)
-
-
-def load_existing_model(weights_path, config_path, device):
-    with open(config_path) as f:
-        model_config = json.load(f)
+def load_existing_model(weights_path, device):
+    metadata, state_dict = _load_state_and_metadata(weights_path, device)
     network_params = {
-        "history_feature_dim": model_config["input_feature_dim"],
-        "card_feature_dim": model_config.get("card_feature_dim", 17),
-        "hidden_dim": model_config["hidden_dim"],
-        "num_heads": model_config["num_heads"],
-        "num_layers": model_config["num_layers"],
-        "num_actions": model_config["num_actions"],
+        "history_feature_dim": metadata["history_feature_dim"],
+        "card_feature_dim": metadata["card_feature_dim"],
+        "hidden_dim": metadata["hidden_dim"],
+        "num_heads": metadata["num_heads"],
+        "num_layers": metadata["num_layers"],
+        "num_actions": metadata["num_actions"],
     }
     model = AdvantageNetwork(**network_params)
-    model.load_state_dict(torch.load(weights_path, map_location=device))
+    model.load_state_dict(state_dict)
     print(f"Model loaded from {weights_path}")
-    return TransformerStrategy(model, model_config, device)
+    return TransformerStrategy(model, metadata, device)
 
 
 def initialize_new_model(device):
     print("No existing model found. Initializing a new model.")
     model_config = {
-        "input_feature_dim": 18,
+        "history_feature_dim": 18,
         "card_feature_dim": 17,
         "hidden_dim": 128,
         "num_heads": 2,
@@ -132,9 +129,11 @@ def initialize_new_model(device):
         "num_actions": 10,
         "max_seq_len": 256,
         "d_raw_feature": 18,
+        "input_feature_dim": 18,
+        "d_card_feature": 17,
     }
     network_params = {
-        "history_feature_dim": model_config["input_feature_dim"],
+        "history_feature_dim": model_config["history_feature_dim"],
         "card_feature_dim": model_config["card_feature_dim"],
         "hidden_dim": model_config["hidden_dim"],
         "num_heads": model_config["num_heads"],
@@ -149,34 +148,27 @@ def save_transformer_model(transformer_strategy):
     models_dir = config.MODEL_DIR
     if not os.path.exists(models_dir):
         os.makedirs(models_dir)
-    weight_path, config_path = get_save_paths()
+    weight_path = get_save_path()
 
     save_weights(transformer_strategy, weight_path)
-    save_config(transformer_strategy, config_path)
 
 
-def get_save_paths():
+def get_save_path():
     timestamp = datetime.now().strftime("%y%m%d%H%M%S")
-    weight_path = os.path.join(config.MODEL_DIR, f"{timestamp}_model.pth")
-    config_path = os.path.join(config.MODEL_DIR, f"{timestamp}_model.config.json")
-    return weight_path, config_path
+    return os.path.join(config.MODEL_DIR, f"{timestamp}_model.pth")
 
 
 def save_weights(transformer_strategy, weight_path):
     try:
-        torch.save(transformer_strategy.model.state_dict(), weight_path)
+        metadata = _metadata_from_config(transformer_strategy.config)
+        payload = {
+            "state_dict": transformer_strategy.model.state_dict(),
+            "metadata": metadata,
+        }
+        torch.save(payload, weight_path)
         print(f"Saved model weights to {weight_path}")
     except Exception as e:
         print(f"Error saving model weights: {e}")
-
-
-def save_config(transformer_strategy, config_path):
-    try:
-        with open(config_path, "w") as f:
-            json.dump(transformer_strategy.config, f, indent=4)
-        print(f"Saved model configuration to {config_path}")
-    except Exception as e:
-        print(f"Error saving model configuration: {e}")
 
 
 def reload_weights_if_updated(transformer_strategy, weights_path, last_mtime):
@@ -185,8 +177,9 @@ def reload_weights_if_updated(transformer_strategy, weights_path, last_mtime):
         current_mtime = os.path.getmtime(weights_path)
         if last_mtime is None or current_mtime > last_mtime:
             try:
-                state = torch.load(weights_path, map_location=transformer_strategy.device)
+                metadata, state = _load_state_and_metadata(weights_path, transformer_strategy.device)
                 transformer_strategy.model.load_state_dict(state)
+                transformer_strategy.config.update(metadata)
                 print(
                     f"[Model Reloaded] {datetime.now().isoformat()} - "
                     f"Loaded weights from {weights_path}"
@@ -195,6 +188,88 @@ def reload_weights_if_updated(transformer_strategy, weights_path, last_mtime):
             except Exception as e:
                 print(f"[Model Reloaded] Failed to reload weights: {e}")
     return last_mtime
+
+
+def _metadata_from_config(config_dict: Mapping[str, Any]) -> dict[str, Any]:
+    history = int(
+        config_dict.get(
+            "history_feature_dim",
+            config_dict.get("d_raw_feature", config_dict.get("input_feature_dim", 18)),
+        )
+    )
+    card = int(config_dict.get("card_feature_dim", config_dict.get("d_card_feature", 17)))
+    hidden = int(config_dict.get("hidden_dim", 128))
+    num_heads = int(config_dict.get("num_heads", 2))
+    num_layers = int(config_dict.get("num_layers", 2))
+    num_actions = int(config_dict.get("num_actions", 10))
+    max_seq_len = int(config_dict.get("max_seq_len", 256))
+
+    metadata: dict[str, Any] = {
+        "history_feature_dim": history,
+        "card_feature_dim": card,
+        "hidden_dim": hidden,
+        "num_heads": num_heads,
+        "num_layers": num_layers,
+        "num_actions": num_actions,
+        "max_seq_len": max_seq_len,
+    }
+
+    trainer = config_dict.get("trainer")
+    if trainer is not None:
+        metadata["trainer"] = trainer
+
+    return metadata
+
+
+def _load_state_and_metadata(
+    path: str, device: torch.device
+) -> tuple[dict[str, Any], Mapping[str, torch.Tensor]]:
+    payload = torch.load(path, map_location=device)
+    if not isinstance(payload, Mapping):
+        raise ValueError("Model file is missing metadata payload")
+
+    metadata_obj = payload.get("metadata")
+    if not isinstance(metadata_obj, Mapping):
+        raise ValueError("Model metadata missing or malformed")
+
+    state_dict = payload.get("state_dict")
+    if not isinstance(state_dict, Mapping):
+        raise ValueError("Model payload missing state_dict")
+
+    metadata = _normalize_metadata(metadata_obj)
+    return metadata, state_dict
+
+
+def _normalize_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        history_feature_dim = int(metadata["history_feature_dim"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("Invalid model metadata: missing history_feature_dim") from exc
+
+    try:
+        num_actions = int(metadata["num_actions"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("Invalid model metadata: missing num_actions") from exc
+
+    card_feature_dim = int(metadata.get("card_feature_dim", history_feature_dim))
+    hidden_dim = int(metadata.get("hidden_dim", 128))
+    num_heads = int(metadata.get("num_heads", 4))
+    num_layers = int(metadata.get("num_layers", 2))
+    max_seq_len = int(metadata.get("max_seq_len", 256))
+
+    normalized = dict(metadata)
+    normalized["history_feature_dim"] = history_feature_dim
+    normalized["card_feature_dim"] = card_feature_dim
+    normalized["hidden_dim"] = hidden_dim
+    normalized["num_heads"] = num_heads
+    normalized["num_layers"] = num_layers
+    normalized["num_actions"] = num_actions
+    normalized["max_seq_len"] = max_seq_len
+    normalized.setdefault("d_raw_feature", history_feature_dim)
+    normalized.setdefault("input_feature_dim", history_feature_dim)
+    normalized.setdefault("d_card_feature", card_feature_dim)
+
+    return normalized
 
 
 def append_common_actions(actions):

--- a/src/poker_ai/gui/playStrategy.py
+++ b/src/poker_ai/gui/playStrategy.py
@@ -76,7 +76,13 @@ class ModelAIStrategy(PlayerStrategy):
     @torch.no_grad()
     def choose_action(self, game, player_index):
         max_seq_len = self.config.get("max_seq_len", 256)
-        d_raw_feature = self.config.get("d_raw_feature", self.config.get("input_feature_dim", 18))
+        d_raw_feature = self.config.get(
+            "d_raw_feature",
+            self.config.get(
+                "input_feature_dim",
+                self.config.get("history_feature_dim", 18),
+            ),
+        )
         hole, community, history = prepare_transformer_input(
             game, player_index, max_seq_len, d_raw_feature
         )

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -1,4 +1,3 @@
-import json
 import warnings
 from pathlib import Path
 from unittest.mock import patch
@@ -8,7 +7,8 @@ import torch
 
 from poker_ai.ai.model_loader import load_model_strategy
 from poker_ai.ai.models.transformer import AdvantageNetwork
-from poker_ai.gui.playStrategy import ModelAIStrategy, PlayerStrategy, RandomAIStrategy
+from poker_ai.ai.trainers.single_network_cfr_trainer import SingleNetworkCFRTrainer
+from poker_ai.gui.playStrategy import ModelAIStrategy, RandomAIStrategy
 
 
 @pytest.fixture
@@ -22,78 +22,100 @@ def cpu_only() -> None:
 @pytest.mark.parametrize("model_exists", [True, False])
 def test_load_model_strategy(tmp_path: Path, model_exists: bool) -> None:
     model_path = tmp_path / "cfr_model.pth"
+    metadata = {
+        "history_feature_dim": 18,
+        "card_feature_dim": 17,
+        "hidden_dim": 16,
+        "num_heads": 2,
+        "num_layers": 1,
+        "num_actions": 4,
+        "max_seq_len": 32,
+    }
     if model_exists:
-        config = {
-            "input_feature_dim": 18,
-            "hidden_dim": 16,
-            "num_heads": 2,
-            "num_layers": 1,
-            "num_actions": 4,
-        }
         model = AdvantageNetwork(
-            history_feature_dim=config["input_feature_dim"],
-            card_feature_dim=config["input_feature_dim"],
-            hidden_dim=config["hidden_dim"],
-            num_heads=config["num_heads"],
-            num_layers=config["num_layers"],
-            num_actions=config["num_actions"],
+            history_feature_dim=metadata["history_feature_dim"],
+            card_feature_dim=metadata["card_feature_dim"],
+            hidden_dim=metadata["hidden_dim"],
+            num_heads=metadata["num_heads"],
+            num_layers=metadata["num_layers"],
+            num_actions=metadata["num_actions"],
         )
-        torch.save(model.state_dict(), model_path)
-        config_path = model_path.with_suffix(".config.json")
-        config_path.write_text(json.dumps(config))
-        strategy_cls: type[PlayerStrategy] = ModelAIStrategy
+        payload = {"state_dict": model.state_dict(), "metadata": metadata}
+        torch.save(payload, model_path)
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             strategy, device = load_model_strategy(str(model_path))
+        assert isinstance(strategy, ModelAIStrategy)
+        assert strategy.config["history_feature_dim"] == metadata["history_feature_dim"]
+        assert strategy.config["card_feature_dim"] == metadata["card_feature_dim"]
     else:
-        strategy_cls = RandomAIStrategy
         with pytest.warns(RuntimeWarning):
             strategy, device = load_model_strategy(str(model_path))
+        assert isinstance(strategy, RandomAIStrategy)
 
-    assert isinstance(strategy, strategy_cls)
     assert isinstance(device, torch.device)
     assert device.type == "cpu"
 
 
 @pytest.mark.usefixtures("cpu_only")
 @pytest.mark.parametrize(
-    "config_writer, model_writer",
+    "payload_factory",
     [
-        (None, torch.save),
-        (lambda path, data: path.write_text(json.dumps(data)), None),
-        (lambda path, data: path.write_text("invalid json"), torch.save),
+        lambda state: state,
+        lambda state: {},
+        lambda state: {"state_dict": state},
+        lambda state: {"metadata": {"history_feature_dim": 18, "num_actions": 4}},
+        lambda state: {
+            "state_dict": state,
+            "metadata": {"history_feature_dim": 18, "num_actions": 4},
+        },
+        lambda state: {"state_dict": state, "metadata": "invalid"},
     ],
 )
 def test_load_model_strategy_fallback(
-    tmp_path: Path, config_writer, model_writer
+    tmp_path: Path, payload_factory
 ) -> None:
     model_path = tmp_path / "cfr_model.pth"
-    config_path = model_path.with_suffix(".config.json")
-    config = {
-        "input_feature_dim": 18,
+    metadata = {
+        "history_feature_dim": 18,
+        "card_feature_dim": 17,
         "hidden_dim": 16,
         "num_heads": 2,
         "num_layers": 1,
         "num_actions": 4,
     }
     model = AdvantageNetwork(
-        history_feature_dim=config["input_feature_dim"],
-        card_feature_dim=config["input_feature_dim"],
-        hidden_dim=config["hidden_dim"],
-        num_heads=config["num_heads"],
-        num_layers=config["num_layers"],
-        num_actions=config["num_actions"],
+        history_feature_dim=metadata["history_feature_dim"],
+        card_feature_dim=metadata["card_feature_dim"],
+        hidden_dim=metadata["hidden_dim"],
+        num_heads=metadata["num_heads"],
+        num_layers=metadata["num_layers"],
+        num_actions=metadata["num_actions"],
     )
 
-    if config_writer is not None:
-        config_writer(config_path, config)
-
-    if model_writer is not None:
-        model_writer(model.state_dict(), model_path)
+    payload = payload_factory(model.state_dict())
+    torch.save(payload, model_path)
 
     with pytest.warns(RuntimeWarning):
         strategy, device = load_model_strategy(str(model_path))
 
     assert isinstance(strategy, RandomAIStrategy)
+    assert isinstance(device, torch.device)
+    assert device.type == "cpu"
+
+
+@pytest.mark.usefixtures("cpu_only")
+def test_load_model_strategy_trainer_payload(tmp_path: Path) -> None:
+    model_path = tmp_path / "trainer_model.pth"
+    trainer = SingleNetworkCFRTrainer(input_feature_dim=18, hidden_dim=32, num_actions=4, lr=1e-3)
+    trainer.save_model(str(model_path))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        strategy, device = load_model_strategy(str(model_path))
+
+    assert isinstance(strategy, ModelAIStrategy)
+    assert strategy.config["history_feature_dim"] == trainer.history_feature_dim
+    assert strategy.config["card_feature_dim"] == trainer.card_feature_dim
     assert isinstance(device, torch.device)
     assert device.type == "cpu"


### PR DESCRIPTION
## Summary
- update `load_model_strategy` to consume AdvantageNetwork metadata directly from the saved torch payload and fall back to the random AI when metadata is invalid
- adjust the play CLI, self-play helpers, and model strategy configuration handling to rely on embedded metadata instead of companion .config.json files
- expand the model loader tests to cover metadata failure scenarios and loading a trainer-produced checkpoint without any external configuration file

## Testing
- pytest tests/test_model_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68c92f3c69fc832aa1b43f3e809401df