### PR TITLE
Improve TexasHoldem cloning performance for self-play

### DIFF
--- a/src/poker_ai/engine/texas_holdem.py
+++ b/src/poker_ai/engine/texas_holdem.py
@@ -236,6 +236,41 @@ class TexasHoldemRules:
         suit_symbols = {"h": "♥", "d": "♦", "c": "♣", "s": "♠"}
         return f"{rank}{suit_symbols.get(suit, suit)}"
 
+    def clone(self) -> "TexasHoldemRules":
+        """Return a lightweight copy of the mutable rule state."""
+
+        clone = self.__class__.__new__(self.__class__)
+
+        # Immutable or shared objects can be copied directly.
+        clone.num_players = self.num_players
+        clone.starting_stack = self.starting_stack
+        clone.small_blind = self.small_blind
+        clone.big_blind = self.big_blind
+        clone.logger = self.logger
+        clone.verbose = self.verbose
+        clone.betting_round = self.betting_round
+        clone.dealer_button = self.dealer_button
+        clone.pot = self.pot
+        clone.current_bet = self.current_bet
+        clone.previous_raise_amount = self.previous_raise_amount
+        clone.actions_this_round = self.actions_this_round
+        clone.last_raiser = self.last_raiser
+
+        # Lists are re-created to avoid accidental sharing during simulations.
+        clone.deck = CardDeck(self.deck)
+        clone.hands = [list(hand) for hand in self.hands]
+        clone.community_cards = list(self.community_cards)
+        clone.bets = list(self.bets)
+        clone.player_chips = list(self.player_chips)
+        clone.active_players = list(self.active_players)
+        clone.betting_history = list(self.betting_history)
+        clone.total_bets_this_hand = list(self.total_bets_this_hand)
+
+        if hasattr(self, "current_player"):
+            clone.current_player = self.current_player
+
+        return clone
+
 
 class MockPlayer:
     def __init__(self, player_id: str, hand: list, stack: int):
@@ -268,6 +303,36 @@ class TexasHoldem:
     def _log(self, msg: str) -> None:
         if self.verbose:
             self.logger.info(msg)
+
+    def clone(self) -> "TexasHoldem":
+        """Return a copy containing only the mutable state required for simulation."""
+
+        clone = self.__class__.__new__(self.__class__)
+
+        # Core configuration/state shared across clones.
+        clone.num_players = self.num_players
+        clone.starting_stack = self.starting_stack
+        clone.player_strategies = self.player_strategies
+        clone.history_limit = self.history_limit
+        clone.logger = self.logger
+        clone.verbose = self.verbose
+
+        # Mutable per-hand state.
+        clone.rules = self.rules.clone()
+        clone.end_game_early = self.end_game_early
+        clone.hand_count = self.hand_count
+        clone.current_hand_initial_actions = list(self.current_hand_initial_actions)
+        clone.historical_actions = self.historical_actions
+
+        def _copy_winner(value):
+            if isinstance(value, list):
+                return list(value)
+            return value
+
+        clone.winner = _copy_winner(self.winner)
+        clone.last_winner = _copy_winner(self.last_winner)
+
+        return clone
 
     def initialize_game(self):
         # Reset game state for new hand

--- a/src/poker_ai/selfplay/self_play.py
+++ b/src/poker_ai/selfplay/self_play.py
@@ -2,7 +2,6 @@
 
 # ruff: noqa
 
-import copy
 import random
 from typing import Any
 
@@ -41,7 +40,7 @@ class SelfPlay:
         # 2. Perform a traversal for each player in the hand
         base_reach = [1.0] * num_players
         for traverser_id in range(num_players):
-            self._traverse_mccfr(copy.deepcopy(game), traverser_id, iteration, base_reach.copy())
+            self._traverse_mccfr(game.clone(), traverser_id, iteration, base_reach.copy())
 
         # 3. After the traversals, run a training step on the collected data
 
@@ -117,7 +116,7 @@ class SelfPlay:
     def _advance_street(self, game: TexasHoldem) -> TexasHoldem:
         """Return a cloned game state advanced to the next street with clean betting state."""
 
-        next_game = copy.deepcopy(game)
+        next_game = game.clone()
         next_game.rules.end_betting_round_cleanup()
 
         community_cards = next_game.rules.community_cards
@@ -177,7 +176,7 @@ class SelfPlay:
                     continue
 
                 # Create a new game state for this action
-                next_game = copy.deepcopy(game)
+                next_game = game.clone()
                 action = get_action_from_index(action_idx, next_game, player_id=current_player)
                 action_str, amount = action_to_tuple(action)
                 next_game.process_action(current_player, action_str, amount)
@@ -231,7 +230,7 @@ class SelfPlay:
             action_idx = torch.multinomial(policy, 1).item()
 
             # Create the next game state
-            next_game = copy.deepcopy(game)
+            next_game = game.clone()
             action = get_action_from_index(action_idx, next_game, player_id=current_player)
             action_str, amount = action_to_tuple(action)
             next_game.process_action(current_player, action_str, amount)

--- a/tests/engine/test_texas_holdem_clone.py
+++ b/tests/engine/test_texas_holdem_clone.py
@@ -1,0 +1,86 @@
+import pytest
+
+from poker_ai.engine.texas_holdem import TexasHoldem
+
+
+@pytest.fixture
+def initialized_game():
+    game = TexasHoldem(num_players=3, starting_stack=200, verbose=False)
+    game.rules.big_blind = 20
+    game.rules.small_blind = 10
+    game.initialize_game()
+
+    # Play a simple pre-flop sequence to touch mutable fields.
+    for _ in range(2):
+        current = game.rules.current_player
+        game.process_action(current, "call")
+        game.rules.advance_turn()
+    current = game.rules.current_player
+    game.process_action(current, "check")
+
+    game.winner = [0, 2]
+    game.last_winner = [1]
+    return game
+
+
+def test_clone_preserves_core_state(initialized_game):
+    game = initialized_game
+    clone = game.clone()
+
+    assert clone is not game
+    assert clone.rules is not game.rules
+
+    # Basic scalar attributes
+    assert clone.num_players == game.num_players
+    assert clone.starting_stack == game.starting_stack
+    assert clone.end_game_early == game.end_game_early
+    assert clone.rules.current_player == game.rules.current_player
+    assert clone.rules.current_bet == game.rules.current_bet
+    assert clone.rules.pot == game.rules.pot
+
+    # Lists should be equal but not shared
+    assert clone.rules.deck == game.rules.deck
+    assert clone.rules.deck is not game.rules.deck
+    assert clone.rules.community_cards == game.rules.community_cards
+    assert clone.rules.community_cards is not game.rules.community_cards
+    assert clone.rules.bets == game.rules.bets
+    assert clone.rules.bets is not game.rules.bets
+    assert clone.rules.player_chips == game.rules.player_chips
+    assert clone.rules.player_chips is not game.rules.player_chips
+    assert clone.rules.total_bets_this_hand == game.rules.total_bets_this_hand
+    assert clone.rules.total_bets_this_hand is not game.rules.total_bets_this_hand
+    assert clone.rules.betting_history == game.rules.betting_history
+    assert clone.rules.betting_history is not game.rules.betting_history
+    assert clone.rules.hands == game.rules.hands
+    assert all(c_hand is not o_hand for c_hand, o_hand in zip(clone.rules.hands, game.rules.hands))
+    assert clone.current_hand_initial_actions == game.current_hand_initial_actions
+    assert clone.current_hand_initial_actions is not game.current_hand_initial_actions
+
+    # Winner fields are copied defensively for list-based ties
+    assert clone.winner == game.winner
+    assert clone.winner is not game.winner
+    assert clone.last_winner == game.last_winner
+    assert clone.last_winner is not game.last_winner
+
+
+def test_clone_does_not_mutate_original(initialized_game):
+    game = initialized_game
+    clone = game.clone()
+
+    original_deck_len = len(game.rules.deck)
+
+    clone.rules.bets[0] += 5
+    assert clone.rules.bets[0] != game.rules.bets[0]
+
+    clone.rules.community_cards.append("Ah")
+    assert "Ah" not in game.rules.community_cards
+
+    clone.rules.deck.pop()
+    assert len(clone.rules.deck) == original_deck_len - 1
+    assert len(game.rules.deck) == original_deck_len
+
+    clone.winner.append(1)
+    assert game.winner == [0, 2]
+
+    clone.last_winner.append(2)
+    assert game.last_winner == [1]


### PR DESCRIPTION
## Summary
- add lightweight `clone()` helpers for both `TexasHoldemRules` and `TexasHoldem` so only the mutable simulation state is copied
- refactor the MCCFR self-play traversal to reuse the new cloning API instead of `copy.deepcopy`
- add regression tests proving that cloned engines preserve state while remaining independent
- capture profiling for a representative one-hand training run before/after the change (41.8s ➝ 16.9s, see `/tmp/profile_before.txt` and `/tmp/profile_after.txt`)

## Testing
- PYTHONPATH=src pytest tests/engine/test_texas_holdem_clone.py tests/selfplay
- PYTHONPATH=src python -m cProfile -s tottime training/train.py --num-hands 1 --num-players 2 --starting-stack 100  # before (saved to /tmp/profile_before.txt)
- PYTHONPATH=src python -m cProfile -s tottime training/train.py --num-hands 1 --num-players 2 --starting-stack 100  # after (saved to /tmp/profile_after.txt)


------
https://chatgpt.com/codex/tasks/task_b_68c92f400b4c832aa4499ed23b69836e