### PR TITLE
Fix self-play policy device handling

### DIFF
--- a/src/poker_ai/selfplay/self_play.py
+++ b/src/poker_ai/selfplay/self_play.py
@@ -73,7 +73,10 @@ class SelfPlay:
             advantages = self.cfr_trainer.get_advantages(history_tensor)
 
         # c. Get a mask for legal actions
-        legal_actions_mask = get_legal_actions_mask(game, player_id, self.cfr_trainer.num_actions)
+        legal_actions_mask = get_legal_actions_mask(
+            game, player_id, self.cfr_trainer.num_actions
+        )
+        legal_actions_mask = legal_actions_mask.to(advantages.device)
 
         # d. Regret matching over legal actions only while avoiding propagating -inf/NaN
         #    when masking out illegal moves.
@@ -81,13 +84,13 @@ class SelfPlay:
         positive_advantages = torch.where(
             legal_actions_mask,
             positive_advantages,
-            torch.zeros_like(positive_advantages),
+            torch.zeros_like(positive_advantages, device=advantages.device),
         )
 
         # e. Normalize across legal actions.  If all regrets are non-positive, revert to
         #    a uniform policy over legal actions only.
         sum_positive = positive_advantages.sum()
-        policy = torch.zeros_like(advantages)
+        policy = torch.zeros_like(advantages, device=advantages.device)
         if sum_positive.item() > 0:
             policy[legal_actions_mask] = positive_advantages[legal_actions_mask] / sum_positive
         else:

--- a/tests/test_self_play.py
+++ b/tests/test_self_play.py
@@ -1,6 +1,9 @@
 import os
 import sys
 
+from types import MethodType
+
+import pytest
 import torch
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -55,3 +58,29 @@ def test_play_hand_for_training_runs():
     ):
         data = sp.play_hand_for_training()
     assert isinstance(data, list)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_get_policy_handles_cuda_advantages():
+    trainer = DummyTrainer()
+
+    trainer.get_advantages = MethodType(
+        lambda self, *args, **kwargs: torch.tensor([1.0, -1.0], device="cuda"),
+        trainer,
+    )
+
+    sp = SelfPlay(trainer, {"num_players": 2, "starting_stack": 50})
+
+    with (
+        patch(
+            "poker_ai.selfplay.self_play.prepare_transformer_input",
+            return_value=(torch.zeros(1), torch.zeros(1), torch.zeros(1)),
+        ),
+        patch(
+            "poker_ai.selfplay.self_play.get_legal_actions_mask",
+            return_value=torch.tensor([True, False]),
+        ),
+    ):
+        policy = sp._get_policy(object(), 0)
+
+    assert policy.device.type == "cuda"


### PR DESCRIPTION
## Summary
- ensure legal action masks and zero tensors in self-play use the advantage device
- add a CUDA-specific policy test that skips when CUDA is unavailable

## Testing
- pytest tests/test_self_play.py

------
https://chatgpt.com/codex/tasks/task_b_68c92f3e2e68832aa4991d61abd60094