### PR TITLE
Remove placeholder actions from CLI self-play history

### DIFF
--- a/src/poker_ai/cli/self_play.py
+++ b/src/poker_ai/cli/self_play.py
@@ -74,9 +74,6 @@ class TransformerStrategy:
         return action_to_tuple(action)
 
 
-COMMON_ACTIONS = ["talk", "move"]
-
-
 def parse_args():
     parser = argparse.ArgumentParser(description="Run self-play simulation")
     parser.add_argument("--config", default=None, help="Path to configuration YAML file")
@@ -270,12 +267,6 @@ def _normalize_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
     normalized.setdefault("d_card_feature", card_feature_dim)
 
     return normalized
-
-
-def append_common_actions(actions):
-    return actions + COMMON_ACTIONS
-
-
 def save_game_history(game):
     history_dir = os.path.join(config.BASE_DATA_DIR, "historical_actions")
     if not os.path.exists(history_dir):
@@ -306,7 +297,7 @@ def extract_game_data(game):
     return {
         "hand_number": game.hand_count,
         "dealer": game.rules.dealer_button + 1,
-        "actions": append_common_actions(game.rules.betting_history),
+        "actions": game.rules.betting_history,
         "community_cards": game.rules.community_cards,
         "pot": game.rules.pot,
         "players": game.get_player_status(),

--- a/tests/test_self_play.py
+++ b/tests/test_self_play.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from types import MethodType
+from types import MethodType, SimpleNamespace
 
 import pytest
 import torch
@@ -14,6 +14,7 @@ for p in (src_path, project_root):
 
 from unittest.mock import patch
 
+from poker_ai.cli.self_play import extract_game_data
 from poker_ai.selfplay.self_play import SelfPlay
 
 
@@ -58,6 +59,30 @@ def test_play_hand_for_training_runs():
     ):
         data = sp.play_hand_for_training()
     assert isinstance(data, list)
+
+
+def test_extract_game_data_uses_betting_history_directly():
+    betting_history = [("0", ("bet", 100)), ("1", ("call", 100))]
+    community_cards = ["Ah", "Kd", "Qs"]
+    players = [{"stack": 900}, {"stack": 1100}]
+
+    game = SimpleNamespace(
+        hand_count=7,
+        rules=SimpleNamespace(
+            dealer_button=1,
+            betting_history=betting_history,
+            community_cards=community_cards,
+            pot=200,
+        ),
+        get_player_status=lambda: players,
+    )
+
+    data = extract_game_data(game)
+
+    assert data["actions"] is betting_history
+    assert data["actions"] == betting_history
+    assert data["community_cards"] == community_cards
+    assert data["players"] == players
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")


### PR DESCRIPTION
## Summary
- stop appending placeholder actions when exporting CLI self-play history
- return the engine's betting history directly from `extract_game_data`
- cover the history export with a unit test to guard against regressions

## Testing
- pytest tests/test_self_play.py

------
https://chatgpt.com/codex/tasks/task_b_68c97a9b91d0832aaf1755a18db2a276