### PR TITLE
Update ModelPerformanceAnalyzer to use iteration terminology

### DIFF
--- a/src/poker_ai/cli/train.py
+++ b/src/poker_ai/cli/train.py
@@ -232,7 +232,7 @@ def main() -> None:  # noqa: C901
 
     print("\n--- Configuration ---")
     print(f"Total training iterations: {num_iterations}")
-    print(f"Save model every: {save_model_every_samples} samples")
+    print(f"Save model every: {save_model_every_samples} iterations")
     if save_model_every_n_hands > 0:
         print(f"Save model every {save_model_every_n_hands} hands")
     if save_model_every_minutes > 0:
@@ -275,7 +275,7 @@ def main() -> None:  # noqa: C901
     print("\n--- Starting Training Loop ---")
     analyzer = ModelPerformanceAnalyzer(
         models_dir="models",
-        save_every_samples=save_model_every_samples,
+        save_every_iterations=save_model_every_samples,
         tournament_threshold=10,
         device=device,
     )
@@ -308,7 +308,7 @@ def main() -> None:  # noqa: C901
                 )
                 last_save_time = time.time()
 
-            analyzer.on_iteration_end(cfr_trainer, iteration)
+            analyzer.on_iteration_end(cfr_trainer, iteration=iteration)
     except Exception as e:
         import traceback
 

--- a/src/poker_ai/evaluation/performance_analysis.py
+++ b/src/poker_ai/evaluation/performance_analysis.py
@@ -116,30 +116,30 @@ class ModelPerformanceAnalyzer:
     def __init__(
         self,
         models_dir: str = "models",
-        save_every_samples: int | None = 100000,
+        save_every_iterations: int | None = 100000,
         tournament_threshold: int = 10,
         tournament_size: int = 10,
         games_per_match: int = 10,
         device: str = "cpu",
     ):
         self.models_dir = models_dir
-        if save_every_samples is not None and save_every_samples <= 0:
-            save_every_samples = None
-        self.save_every_samples = save_every_samples
+        if save_every_iterations is not None and save_every_iterations <= 0:
+            save_every_iterations = None
+        self.save_every_iterations = save_every_iterations
         self.tournament_threshold = tournament_threshold
         self.tournament_size = tournament_size
         self.games_per_match = games_per_match
         self.device = device
 
-    def on_iteration_end(self, trainer, sample_count: int) -> None:
-        if self.save_every_samples is None:
+    def on_iteration_end(self, trainer, iteration: int) -> None:
+        if self.save_every_iterations is None:
             return
-        if sample_count % self.save_every_samples != 0:
+        if iteration % self.save_every_iterations != 0:
             return
         os.makedirs(self.models_dir, exist_ok=True)
-        path = os.path.join(self.models_dir, f"model_{sample_count}.pth")
+        path = os.path.join(self.models_dir, f"model_{iteration}.pth")
         trainer.save_model(path)
-        print(f"Model saved to {path}")
+        print(f"Model saved to {path} at iteration {iteration}")
         self._maybe_run_tournament()
 
     def _maybe_run_tournament(self) -> None:

--- a/tests/test_performance_analysis.py
+++ b/tests/test_performance_analysis.py
@@ -37,7 +37,7 @@ class TestPerformanceAnalyzer(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             analyzer = ModelPerformanceAnalyzer(
                 models_dir=tmpdir,
-                save_every_samples=1,
+                save_every_iterations=1,
                 tournament_threshold=2,
                 tournament_size=2,
                 games_per_match=0,
@@ -58,7 +58,7 @@ class TestPerformanceAnalyzer(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             analyzer = ModelPerformanceAnalyzer(
                 models_dir=tmpdir,
-                save_every_samples=0,
+                save_every_iterations=0,
                 device="cpu",
             )
             analyzer.on_iteration_end(trainer, 1)


### PR DESCRIPTION
## Summary
- rename the ModelPerformanceAnalyzer save interval parameter to iteration-based naming
- adjust CLI training script to use the renamed parameter and clarify the related log output
- update unit tests to match the new API

## Testing
- pytest tests/test_performance_analysis.py
- pytest tests/test_cli_train.py

------
https://chatgpt.com/codex/tasks/task_b_68c97a9db134832a9a9d76f6702d3259