### PR TITLE
Disable verbose TexasHoldem logging in self-play trainer

### DIFF
--- a/src/poker_ai/ai/trainers/self_play.py
+++ b/src/poker_ai/ai/trainers/self_play.py
@@ -4,7 +4,8 @@ from poker_ai.engine.texas_holdem import TexasHoldem
 
 def simulate_self_play(trainer: AICFRTrainer, num_games: int):
     for _ in range(num_games):
-        game = TexasHoldem()
+        # Disable verbose engine logging; no training entry points rely on it.
+        game = TexasHoldem(num_players=2, verbose=False)
         game_state_sequence = game.start()
         # Simulate the game using the AI model and update strategies
         trainer.train(game_state_sequence)


### PR DESCRIPTION
## Summary
- disable verbose logging when running self-play training by instantiating the engine with `verbose=False`
- note inline that training entry points do not depend on verbose engine output

## Testing
- pytest tests/test_trainer_integration.py

------
https://chatgpt.com/codex/tasks/task_b_68c97a9d7b6c832a87ef21cc1a68fdf8