### PR TITLE
Use model loader in CLI AI strategy

### DIFF
--- a/src/poker_ai/cli/play_vs_ai.py
+++ b/src/poker_ai/cli/play_vs_ai.py
@@ -8,9 +8,9 @@ import os
 import torch
 
 # ruff: noqa: ANN201,ANN204
-from poker_ai.ai.models.transformer import AdvantageNetwork
+from poker_ai.ai.model_loader import load_model_strategy
 from poker_ai.engine.texas_holdem import TexasHoldem
-from poker_ai.gui.playStrategy import HumanStrategy, PlayerStrategy
+from poker_ai.gui.playStrategy import HumanStrategy, ModelAIStrategy, PlayerStrategy
 from poker_ai.rules.cfr import calculate_strategy
 from poker_ai.utils.action_mapping import (
     action_to_tuple,
@@ -32,68 +32,102 @@ class AIStrategy(PlayerStrategy):
     ):
         self.device = device
         self.num_actions = num_actions
+        self.model = None
+        self.config: dict[str, object] = {}
+        self._fallback_strategy: PlayerStrategy | None = None
+        self.max_seq_len = 256
+        self.feature_dim = 18
 
-        # This assumes the model was saved with a config that matches the network class
-        # For now, we hardcode the model parameters, but a config file would be better.
-        self.model = AdvantageNetwork(
-            history_feature_dim=18,  # This must match the state representation
-            card_feature_dim=18,
-            hidden_dim=128,
-            num_heads=4,
-            num_layers=2,
-            num_actions=self.num_actions,
-        )
-        self.model.load_state_dict(torch.load(model_path, map_location=self.device))
-        self.model.to(self.device)
+        loaded_strategy, loader_device = load_model_strategy(model_path)
 
-        if (
-            use_all_npus
-            and device == "npu"
-            and hasattr(torch, "npu")
-            and torch.npu.is_available()
-            and torch.npu.device_count() > 1
-        ):
-            # Wrap model for multi-NPU inference
-            self.model = torch.nn.DataParallel(self.model)
+        try:
+            target_device = torch.device(device)
+        except (TypeError, ValueError, RuntimeError):
+            target_device = loader_device
 
-        self.model.eval()
+        self._torch_device = target_device
+
+        if isinstance(loaded_strategy, ModelAIStrategy):
+            model = loaded_strategy.model.to(target_device)
+
+            if (
+                use_all_npus
+                and target_device.type == "npu"
+                and hasattr(torch, "npu")
+                and torch.npu.is_available()
+                and torch.npu.device_count() > 1
+            ):
+                model = torch.nn.DataParallel(model)
+
+            self.model = model
+            self.model.eval()
+
+            self.config = dict(loaded_strategy.config)
+            self.max_seq_len = int(self.config.get("max_seq_len", self.max_seq_len))
+            feature_dim = self.config.get(
+                "d_raw_feature",
+                self.config.get(
+                    "input_feature_dim",
+                    self.config.get("history_feature_dim", 18),
+                ),
+            )
+            self.feature_dim = int(feature_dim)
+            configured_num_actions = int(
+                self.config.get(
+                    "num_actions",
+                    getattr(getattr(self.model, "module", self.model), "num_actions", num_actions),
+                )
+            )
+            self.num_actions = configured_num_actions
+            self.config["num_actions"] = self.num_actions
+        else:
+            self._fallback_strategy = loaded_strategy
 
     @property
     def is_human(self):
+        if self._fallback_strategy is not None:
+            return self._fallback_strategy.is_human
         return False
 
     @torch.no_grad()
     def choose_action(self, game: TexasHoldem, player_index: int):
         """Chooses an action by querying the model."""
-        # 1. Get the policy from the network
-        hole, community, history = prepare_transformer_input(game, player_index, 256, 18)
-        advantages = (
-            self.model(
-                hole.unsqueeze(0).to(self.device),
-                community.unsqueeze(0).to(self.device),
-                history.unsqueeze(0).to(self.device),
-            )
-            .squeeze(0)
-            .cpu()
-        )
-
-        # 2. Get legal actions and mask the policy
-        legal_mask = get_legal_actions_mask(game, player_index, self.num_actions)
-        advantages[~legal_mask] = -1e9
-
-        policy = calculate_strategy(advantages, self.num_actions)
-
-        # 3. Sample an action from the policy
-        if policy.sum() > 0:
-            action_idx = torch.multinomial(policy, 1).item()
+        if self.model is None and self._fallback_strategy is not None:
+            result = self._fallback_strategy.choose_action(game, player_index)
+            if isinstance(result, tuple):
+                action_str, amount = result
+            else:
+                action_str, amount = result, None
         else:
-            # Fallback if policy is all zeros (should not happen with legal mask)
-            valid_indices = torch.where(legal_mask)[0]
-            action_idx = valid_indices[torch.randint(0, len(valid_indices), (1,))].item()
+            hole, community, history = prepare_transformer_input(
+                game,
+                player_index,
+                self.max_seq_len,
+                self.feature_dim,
+            )
+            advantages = (
+                self.model(
+                    hole.unsqueeze(0).to(self._torch_device),
+                    community.unsqueeze(0).to(self._torch_device),
+                    history.unsqueeze(0).to(self._torch_device),
+                )
+                .squeeze(0)
+                .cpu()
+            )
 
-        # 4. Convert action index to game action
-        action = get_action_from_index(action_idx, game, player_id=player_index)
-        action_str, amount = action_to_tuple(action)
+            legal_mask = get_legal_actions_mask(game, player_index, self.num_actions)
+            advantages[~legal_mask] = -1e9
+
+            policy = calculate_strategy(advantages, self.num_actions)
+
+            if policy.sum() > 0:
+                action_idx = torch.multinomial(policy, 1).item()
+            else:
+                valid_indices = torch.where(legal_mask)[0]
+                action_idx = valid_indices[torch.randint(0, len(valid_indices), (1,))].item()
+
+            action = get_action_from_index(action_idx, game, player_id=player_index)
+            action_str, amount = action_to_tuple(action)
 
         print(
             "AI (Player {player_index + 1}) chose action: "

--- a/tests/test_cli_play_vs_ai.py
+++ b/tests/test_cli_play_vs_ai.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+
+from poker_ai.ai.trainers.single_network_cfr_trainer import SingleNetworkCFRTrainer
+from poker_ai.cli import play_vs_ai
+
+
+def test_cli_strategy_uses_loader_metadata(monkeypatch, tmp_path: Path) -> None:
+    trainer = SingleNetworkCFRTrainer(
+        input_feature_dim=21,
+        hidden_dim=32,
+        num_actions=5,
+        lr=1e-3,
+        device="cpu",
+    )
+    model_path = tmp_path / "trainer_strategy.pth"
+    trainer.save_model(str(model_path))
+
+    strategy = play_vs_ai.AIStrategy(str(model_path), device="cpu")
+
+    assert strategy.model is not None
+    assert strategy.feature_dim == trainer.history_feature_dim
+    assert strategy.max_seq_len == trainer.max_seq_len
+    assert strategy.num_actions == trainer.num_actions
+
+    captured: dict[str, int] = {}
+
+    def fake_prepare(game, player_index, max_seq_len, feature_dim):
+        captured["max_seq_len"] = max_seq_len
+        captured["feature_dim"] = feature_dim
+        card_dim = trainer.card_feature_dim
+        hole = torch.zeros(card_dim, dtype=torch.float32)
+        community = torch.zeros(card_dim, dtype=torch.float32)
+        history = torch.zeros(max_seq_len, feature_dim, dtype=torch.float32)
+        return hole, community, history
+
+    monkeypatch.setattr(play_vs_ai, "prepare_transformer_input", fake_prepare)
+    monkeypatch.setattr(
+        play_vs_ai,
+        "get_legal_actions_mask",
+        lambda game, player_index, num_actions: torch.ones(num_actions, dtype=torch.bool),
+    )
+
+    def fake_strategy(advantages, num_actions):
+        return advantages.new_full((num_actions,), 1.0 / num_actions)
+
+    monkeypatch.setattr(play_vs_ai, "calculate_strategy", fake_strategy)
+    monkeypatch.setattr(
+        play_vs_ai,
+        "get_action_from_index",
+        lambda idx, game, player_id: ("call", None),
+    )
+    monkeypatch.setattr(play_vs_ai.torch, "multinomial", lambda policy, k: torch.tensor([0]))
+
+    action, amount = strategy.choose_action(game=None, player_index=0)
+
+    assert action == "call"
+    assert amount is None
+    assert captured["max_seq_len"] == trainer.max_seq_len
+    assert captured["feature_dim"] == trainer.history_feature_dim


### PR DESCRIPTION
## Summary
- reuse `load_model_strategy` in the CLI AI wrapper so checkpoints provide model/device configuration
- drive CLI inference from loader metadata, including dynamic history dimensions and max sequence length
- add a regression test confirming the CLI can load trainer-generated checkpoints and feed metadata to state preparation

## Testing
- pytest tests/test_model_loader.py tests/test_cli_play_vs_ai.py

------
https://chatgpt.com/codex/tasks/task_b_68ca4128bf88832ab5238f5709c0ac29