### PR TITLE
Make AI action log show player index

### DIFF
--- a/src/poker_ai/cli/play_vs_ai.py
+++ b/src/poker_ai/cli/play_vs_ai.py
@@ -96,7 +96,7 @@ class AIStrategy(PlayerStrategy):
         action_str, amount = action_to_tuple(action)
 
         print(
-            "AI (Player {player_index + 1}) chose action: "
+            f"AI (Player {player_index + 1}) chose action: "
             f"{action_str} {amount if amount is not None else ''}"
         )
         return action_str, amount


### PR DESCRIPTION
## Summary
- convert the AI action announcement in the CLI to use an f-string so the player index is interpolated

## Testing
- `PYTHONPATH=src python - <<'PY' ...` (patched dependencies to simulate a game state and confirm the log prints "AI (Player 2) chose action: call")

------
https://chatgpt.com/codex/tasks/task_b_68ca412a25f0832ab99ef1a40db685d1