### PR TITLE
Add configurable replay buffer threshold for training

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,12 @@ To control the computation device you can use:
 - `--gpus` to train on available GPUs (uses all GPUs via `DataParallel`).
 - `--npus` to train on available NPUs (uses all NPUs via `DataParallel`).
 
+For faster iteration during small experiments you can lower the minimum replay
+buffer required before training with:
+
+- `--min-buffer-before-train 64` to start optimization steps once 64 samples
+  have been collected (defaults to 256).
+
 Omitting these flags runs training on the CPU by default.
 
 

--- a/src/poker_ai/cli/train.py
+++ b/src/poker_ai/cli/train.py
@@ -31,6 +31,11 @@ def parse_args() -> argparse.Namespace:
         help="Save model every N samples/hands for performance analysis",
     )
     parser.add_argument(
+        "--min-buffer-before-train",
+        type=int,
+        help="Replay buffer size required before triggering a training batch",
+    )
+    parser.add_argument(
         "--algorithm",
         default="deep_cfr",
         choices=["ai_cfr", "deep_cfr", "single_network"],
@@ -145,6 +150,7 @@ def main() -> None:  # noqa: C901
         "save_model_every",
         "save_minutes",
         "save_samples",
+        "min_buffer_before_train",
     ):
         if isinstance(getattr(args, attr, None), MagicMock):
             setattr(args, attr, None)
@@ -223,6 +229,15 @@ def main() -> None:  # noqa: C901
         else training_params.get("save_model_every_samples", 100000)
     )
 
+    min_buffer_override = args.min_buffer_before_train
+    if min_buffer_override is not None:
+        min_buffer_before_train = int(min_buffer_override)
+    else:
+        min_buffer_before_train = int(
+            training_params.get("min_buffer_before_train", 256)
+        )
+    training_params["min_buffer_before_train"] = min_buffer_before_train
+
     # Game Engine Parameters for SelfPlay
     min_players = game_engine_config.get("min_players", 2)
     max_players = game_engine_config.get("max_players", 10)
@@ -241,6 +256,7 @@ def main() -> None:  # noqa: C901
     print(f"Starting stack: {starting_stack}")
     print(f"Blinds: SB={small_blind}, BB={big_blind}")
     print(f"Using device: {device}")
+    print(f"Min buffer before training: {min_buffer_before_train}")
 
     # Initialization
     print("\n--- Initializing Components ---")
@@ -269,7 +285,11 @@ def main() -> None:  # noqa: C901
 
     # The new SelfPlay class for MCCFR doesn't need curriculum learning or complex setup.
     # It's simplified for the core algorithm.
-    self_play_env = SelfPlay(cfr_trainer=cfr_trainer, game_engine_config=game_config_for_selfplay)
+    self_play_env = SelfPlay(
+        cfr_trainer=cfr_trainer,
+        game_engine_config=game_config_for_selfplay,
+        training_config=training_params,
+    )
 
     # Training Loop
     print("\n--- Starting Training Loop ---")

--- a/src/poker_ai/config/config.yaml
+++ b/src/poker_ai/config/config.yaml
@@ -16,6 +16,7 @@ training:
   cfr_discount_factor: 1.0 # Discount factor for discounted CFR+
   distributed_workers: 1 # Number of workers for distributed self-play
   save_model_path: "trained_models/cfr_model.pth" # Moved from model section for ai_cfr_trainer compatibility
+  min_buffer_before_train: 256 # Minimum replay buffer size before starting a training step
   # CFR+ specific parameters (if used)
   # cfr_plus_alpha: 1.5 # Alpha parameter for CFR+ (controls regret weighting)
   # cfr_plus_beta: 0.5  # Beta parameter for CFR+ (controls strategy weighting)

--- a/src/poker_ai/selfplay/distributed_self_play.py
+++ b/src/poker_ai/selfplay/distributed_self_play.py
@@ -12,9 +12,15 @@ def _run_hand(args: dict[str, Any]) -> list[Any]:
 
 
 class DistributedSelfPlay:
-    def __init__(self, cfr_trainer, game_engine_config: dict[str, Any]):
+    def __init__(
+        self,
+        cfr_trainer,
+        game_engine_config: dict[str, Any],
+        training_config: dict[str, Any] | None = None,
+    ):
         self.cfr_trainer = cfr_trainer
         self.game_engine_config = game_engine_config
+        self.training_config = training_config
 
     def run(self, num_hands: int, num_workers: int = 2) -> list[list[Any]]:
         """Execute multiple hands in parallel and collect results."""
@@ -23,7 +29,11 @@ class DistributedSelfPlay:
             hands_per_worker[i] += 1
         tasks = []
         for count in hands_per_worker:
-            sp = SelfPlay(self.cfr_trainer, self.game_engine_config)
+            sp = SelfPlay(
+                self.cfr_trainer,
+                self.game_engine_config,
+                training_config=self.training_config,
+            )
             for _ in range(count):
                 tasks.append({"self_play": sp})
         with Pool(processes=num_workers) as pool:

--- a/src/poker_ai/selfplay/self_play.py
+++ b/src/poker_ai/selfplay/self_play.py
@@ -20,13 +20,25 @@ from poker_ai.utils.state_representation import prepare_transformer_input
 class SelfPlay:
     """Orchestrates MCCFR traversals for training data generation."""
 
-    def __init__(self, cfr_trainer: object, game_engine_config: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        cfr_trainer: object,
+        game_engine_config: dict[str, Any],
+        training_config: dict[str, Any] | None = None,
+    ) -> None:
         self.cfr_trainer = cfr_trainer
         self.starting_stack = game_engine_config.get("starting_stack", 1000)
         self.big_blind = game_engine_config.get("big_blind", 10)
         self.small_blind = game_engine_config.get("small_blind", 5)
         self.min_players = game_engine_config.get("min_players", 2)
         self.max_players = game_engine_config.get("max_players", 10)
+        cfg = training_config or {}
+        min_buffer_raw = cfg.get("min_buffer_before_train", 256)
+        try:
+            min_buffer = int(min_buffer_raw)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            min_buffer = 256
+        self.min_buffer_before_train = max(1, min_buffer)
 
     def play_hand_for_training(self, iteration: int = 0) -> list[Any]:
         """Run one full MCCFR traversal for a new hand."""
@@ -44,8 +56,8 @@ class SelfPlay:
 
         # 3. After the traversals, run a training step on the collected data
 
-        if len(self.cfr_trainer.replay_buffer) >= 256:
-            loss = self.cfr_trainer.train(batch_size=256)
+        if len(self.cfr_trainer.replay_buffer) >= self.min_buffer_before_train:
+            loss = self.cfr_trainer.train(batch_size=self.min_buffer_before_train)
             if loss is not None:
                 print(f"Iteration {iteration}: Training step complete. Loss: {loss:.4f}")
 

--- a/tests/test_run_training.py
+++ b/tests/test_run_training.py
@@ -48,6 +48,7 @@ class TestRunTraining(unittest.TestCase):
         args_mock.device = None
         args_mock.gpus = False
         args_mock.npus = False
+        args_mock.min_buffer_before_train = None
 
         training_params_mock = {
             "save_model_every_minutes": save_interval_minutes,
@@ -102,6 +103,7 @@ class TestRunTraining(unittest.TestCase):
         args_mock.device = None
         args_mock.gpus = False
         args_mock.npus = False
+        args_mock.min_buffer_before_train = None
 
         training_params_mock = {
             "save_model_every_minutes": 0,
@@ -156,6 +158,7 @@ class TestRunTraining(unittest.TestCase):
         args_mock.device = None
         args_mock.gpus = False
         args_mock.npus = False
+        args_mock.min_buffer_before_train = None
 
         training_params_mock = {
             "save_model_every_minutes": args_mock.save_minutes,

--- a/tests/test_self_play.py
+++ b/tests/test_self_play.py
@@ -12,7 +12,7 @@ for p in (src_path, project_root):
     if p not in sys.path:
         sys.path.insert(0, p)
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from poker_ai.cli.self_play import extract_game_data
 from poker_ai.selfplay.self_play import SelfPlay
@@ -59,6 +59,38 @@ def test_play_hand_for_training_runs():
     ):
         data = sp.play_hand_for_training()
     assert isinstance(data, list)
+
+
+def test_play_hand_for_training_respects_custom_buffer_threshold():
+    trainer = DummyTrainer()
+    trainer.replay_buffer.extend([object(), object()])
+    trainer.train = MagicMock(return_value=None)
+
+    training_cfg = {"min_buffer_before_train": 2}
+    sp = SelfPlay(
+        trainer,
+        {"num_players": 2, "starting_stack": 50},
+        training_config=training_cfg,
+    )
+
+    class DummyGame:
+        def __init__(self, num_players: int, starting_stack: int) -> None:
+            self.rules = SimpleNamespace(big_blind=0, small_blind=0, num_players=num_players)
+
+        def initialize_game(self) -> None:
+            pass
+
+        def clone(self) -> "DummyGame":
+            return self
+
+    with (
+        patch("poker_ai.selfplay.self_play.random.randint", return_value=2),
+        patch("poker_ai.selfplay.self_play.TexasHoldem", DummyGame),
+        patch.object(SelfPlay, "_traverse_mccfr", return_value=0),
+    ):
+        sp.play_hand_for_training(iteration=123)
+
+    trainer.train.assert_called_once_with(batch_size=2)
 
 
 def test_extract_game_data_uses_betting_history_directly():


### PR DESCRIPTION
## Summary
- add a configurable `min_buffer_before_train` option surfaced through config files and the CLI
- teach SelfPlay and DistributedSelfPlay to honor the configurable replay buffer threshold when triggering training
- document the new flag and cover the customizable behavior with unit tests

## Testing
- pytest tests/test_self_play.py tests/test_run_training.py


------
https://chatgpt.com/codex/tasks/task_b_68ca412be224832a8f174f69af745db9