### PR TITLE
Fix side pot handling for folded contributions

### DIFF
--- a/src/gatc_poker/__init__.py
+++ b/src/gatc_poker/__init__.py
@@ -1,6 +1,25 @@
 """GATC Poker helpers: rules-safe side pots and hand evaluation wrappers."""
 
-from .handeval import best_of, evaluate_hand  # noqa: F401
-from .pots import SidePot, compute_side_pots  # noqa: F401
+from __future__ import annotations
+
+from typing import Iterable
+
+from .pots import SidePot, compute_side_pots
 
 __all__ = ["best_of", "evaluate_hand", "compute_side_pots", "SidePot"]
+
+
+def evaluate_hand(hole: Iterable[str], board: Iterable[str]) -> int:
+    """Proxy for :func:`gatc_poker.handeval.evaluate_hand` with lazy import."""
+
+    from .handeval import evaluate_hand as _evaluate_hand
+
+    return _evaluate_hand(list(hole), list(board))
+
+
+def best_of(players_hole: dict[int, list[str]], board: Iterable[str]) -> list[int]:
+    """Proxy for :func:`gatc_poker.handeval.best_of` with lazy import."""
+
+    from .handeval import best_of as _best_of
+
+    return _best_of(players_hole, list(board))

--- a/src/gatc_poker/pots.py
+++ b/src/gatc_poker/pots.py
@@ -26,27 +26,54 @@ def compute_side_pots(contrib: dict[int, int], in_showdown: set[int]) -> list[Si
 
     contributions = {int(p): max(0, int(a)) for p, a in contrib.items()}
 
-    # Build sorted positive contribution levels
-    levels = sorted({a for a in contributions.values() if a > 0})
+    # Track players grouped by their exact contribution so we can update the
+    # "who is still matching this level" sets without rescanning everything.
+    players_by_amount: dict[int, set[int]] = {}
+    positive_players: set[int] = set()
+    showdown_players: set[int] = set()
+    for pid, amount in contributions.items():
+        if amount <= 0:
+            continue
+        players_by_amount.setdefault(amount, set()).add(pid)
+        positive_players.add(pid)
+        if pid in in_showdown:
+            showdown_players.add(pid)
+
+    if not positive_players or not showdown_players:
+        return []
+
+    # Sorted unique contribution levels ("thresholds")
+    levels = sorted(players_by_amount)
     pots: list[SidePot] = []
     prev = 0
+    carry = 0
+    current_all = set(positive_players)
+    current_showdown = set(showdown_players)
 
     for lvl in levels:
+        removal = players_by_amount.get(prev)
+        if removal:
+            current_all.difference_update(removal)
+            current_showdown.difference_update(removal)
+
         delta = lvl - prev
-        if delta <= 0:
+        if delta <= 0 or not current_all:
             prev = lvl
             continue
 
-        # Eligible seats for this pot: players who reached at least this level and didn't fold
-        participants = {p for p, a in contributions.items() if a >= lvl and p in in_showdown}
-        if not participants:
-            prev = lvl
-            continue
-
-        # Amount in this band for all contributors (including folded players' chips)
-        amount = sum(max(min(a, lvl) - prev, 0) for a in contributions.values())
-        if amount > 0:
-            pots.append(SidePot(amount=amount, eligible=frozenset(participants)))
+        band_total = delta * len(current_all)
+        eligible = frozenset(current_showdown)
+        if eligible:
+            amount = band_total + carry
+            if amount > 0:
+                pots.append(SidePot(amount=amount, eligible=eligible))
+            carry = 0
+        else:
+            carry += band_total
         prev = lvl
+
+    if carry and pots:
+        last = pots[-1]
+        pots[-1] = SidePot(amount=last.amount + carry, eligible=last.eligible)
 
     return pots

--- a/src/poker_ai/engine/texas_holdem.py
+++ b/src/poker_ai/engine/texas_holdem.py
@@ -8,9 +8,10 @@ import json
 import logging
 import os
 import random
-from typing import Optional, cast
+from typing import Optional
 
 from gatc_holdem.engine.rules import min_raise_to
+from gatc_poker.pots import compute_side_pots as gatc_compute_side_pots
 
 # ``treys`` provides fast poker hand evaluation but is optional in our test
 # environment.  To keep the engine lightweight, we attempt to import the real
@@ -814,27 +815,21 @@ class TexasHoldem:
         return score, sorted(hole + board), rank_class
 
     def _compute_side_pots(self) -> list[dict[str, object]]:
-        """Compute side pots from total contributions. Returns a list of dicts:
-        [{ 'amount': int, 'eligible': set(player_indices) }, ...]
-        Pots are ordered from smallest (main) to largest side pot."""
-        contrib = self.rules.total_bets_this_hand[:]
-        thresholds = sorted({c for c in contrib if c > 0})
-        pots: list[dict[str, object]] = []
-        prev = 0
-        for t in thresholds:
-            elig = {i for i, c in enumerate(contrib) if c >= t}
-            if not elig:
-                prev = t
-                continue
-            layer = (t - prev) * len(elig)
-            if layer > 0:
-                pots.append({"amount": layer, "eligible": elig})
-            prev = t
-        for p in pots:
-            p["eligible"] = {
-                i for i in cast(set[int], p["eligible"]) if self.rules.active_players[i]
-            }
-        return pots
+        """Compute side pots using the shared helper from :mod:`gatc_poker`."""
+
+        contributions: dict[int, int] = {}
+        for idx, amount in enumerate(self.rules.total_bets_this_hand):
+            chips = int(amount)
+            if chips > 0:
+                contributions[idx] = chips
+        in_showdown = {
+            idx for idx, active in enumerate(self.rules.active_players) if active
+        }
+        pots = gatc_compute_side_pots(contributions, in_showdown)
+        return [
+            {"amount": pot.amount, "eligible": set(pot.eligible)}
+            for pot in pots
+        ]
 
     def perform_showdown(self) -> tuple[dict[int, int], dict[int, int]]:
         """Evaluate all active players' hands and build side pots.
@@ -859,8 +854,8 @@ class TexasHoldem:
 
         winnings: dict[int, int] = {i: 0 for i in range(self.num_players)}
         for pot in pots:
-            amount: int = int(pot["amount"])  # type: ignore
-            elig: set[int] = pot["eligible"]  # type: ignore
+            amount = int(pot["amount"])
+            elig = set(pot["eligible"])
             if not elig or amount <= 0:
                 continue
             best_score = min(scores[i][0] for i in elig)
@@ -1023,11 +1018,11 @@ class TexasHoldem:
         redistributed: dict[int, int] = {i: 0 for i in range(self.num_players)}
 
         for idx, pot in enumerate(pots):
-            amount = int(cast(int, pot["amount"]))
+            amount = int(pot["amount"])
             if amount <= 0:
                 continue
 
-            eligible = cast(set[int], pot["eligible"])
+            eligible = set(pot["eligible"])
             pot_name = "main pot" if idx == 0 else f"side pot {idx}"
 
             if winner_player_index in eligible or not eligible:

--- a/tests/test_gatc_side_pots_extra.py
+++ b/tests/test_gatc_side_pots_extra.py
@@ -1,0 +1,27 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    root = Path(__file__).resolve().parents[1]
+    module_path = root / "src" / "gatc_poker" / "pots.py"
+    spec = importlib.util.spec_from_file_location("_gatc_pots_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_gatc_pots_test"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_folded_player_extra_contribution_attaches_to_last_live_pot():
+    pots_module = _load_module()
+    pots = pots_module.compute_side_pots({0: 100, 1: 50, 2: 200}, {0, 1})
+    assert [p.amount for p in pots] == [150, 200]
+    assert [set(p.eligible) for p in pots] == [{0, 1}, {0}]
+
+
+def test_zero_contributions_or_no_showdown_returns_empty():
+    pots_module = _load_module()
+    assert pots_module.compute_side_pots({}, {0}) == []
+    assert pots_module.compute_side_pots({0: 100}, set()) == []


### PR DESCRIPTION
## Summary
- fix `gatc_poker.compute_side_pots` to carry folded chips into the highest eligible pot and avoid repeated rescans
- reuse the shared side-pot helper inside the engine so folded contributions are always awarded correctly
- add regression tests covering folded players with excess chips and empty showdowns

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_b_68cb9d35b104832abebd99af3d2c45c0