### PR TITLE
Fix best_of duplicate handling and optimize card evaluation

### DIFF
--- a/src/gatc_poker/handeval.py
+++ b/src/gatc_poker/handeval.py
@@ -41,6 +41,12 @@ def best_of(players_hole: dict[int, list[str]], board: list[str]) -> list[int]:
     Validates cards and rejects duplicates across all players + board.
     """
     board_norm = [_normalize(c) for c in board]
+    if len(board_norm) != len(set(board_norm)):
+        raise ValueError("Duplicate card detected on the board")
+
+    # Cache eval7.Card objects so we only construct each physical card once.
+    card_cache: dict[str, eval7.Card] = {c: eval7.Card(c) for c in board_norm}
+    board_cards = [card_cache[c] for c in board_norm]
     seen = set(board_norm)
     scores: dict[int, int] = {}
 
@@ -48,11 +54,14 @@ def best_of(players_hole: dict[int, list[str]], board: list[str]) -> list[int]:
         if len(hole) != 2:
             raise ValueError(f"Player {pid} must have exactly 2 hole cards")
         hole_norm = [_normalize(c) for c in hole]
+        if len(hole_norm) != len(set(hole_norm)):
+            raise ValueError(f"Player {pid} has duplicate hole cards")
         for c in hole_norm:
             if c in seen:
                 raise ValueError(f"Duplicate card detected: {c}")
             seen.add(c)
-        scores[pid] = eval7.evaluate([eval7.Card(c) for c in (hole_norm + board_norm)])
+        hole_cards = [card_cache.setdefault(c, eval7.Card(c)) for c in hole_norm]
+        scores[pid] = eval7.evaluate(hole_cards + board_cards)
 
     max_score = max(scores.values())
     return [pid for pid, sc in scores.items() if sc == max_score]

--- a/tests/test_handeval.py
+++ b/tests/test_handeval.py
@@ -26,3 +26,14 @@ def test_board_plays_everyone_ties() -> None:
     }
     winners = best_of(players, board)
     assert set(winners) == {0, 1, 2}
+
+
+def test_duplicate_board_cards_raise() -> None:
+    board = ["As", "As", "Kd", "Qc", "Jd"]
+    players = {
+        0: ["2c", "3d"],
+        1: ["4h", "5s"],
+    }
+
+    with pytest.raises(ValueError, match="Duplicate card"):
+        best_of(players, board)


### PR DESCRIPTION
## Summary
- validate duplicate cards on the board and in each player's hole when determining winners
- reuse eval7 card objects so hand ranking skips repeated conversions
- add a regression test for duplicate community cards raising an error

## Testing
- pytest tests/test_handeval.py tests/test_handeval_extra.py -vv

------
https://chatgpt.com/codex/tasks/task_b_68cbbf680310832aaa3928cc7d03378e