### PR TITLE
Handle short blind stacks in post_blinds

### DIFF
--- a/src/poker_ai/engine/texas_holdem.py
+++ b/src/poker_ai/engine/texas_holdem.py
@@ -114,26 +114,35 @@ class TexasHoldemRules:
         small_blind_player = (self.dealer_button + 1) % self.num_players
         big_blind_player = (self.dealer_button + 2) % self.num_players
 
+        def _post_blind(player_index: int, blind_amount: int, label: str) -> int:
+            available_chips = self.player_chips[player_index]
+            contribution = min(available_chips, blind_amount)
+            self.player_chips[player_index] -= contribution
+            if self.player_chips[player_index] < 0:  # Safety guard in case of negative values
+                self.player_chips[player_index] = 0
+            self.bets[player_index] = contribution
+            self.pot += contribution
+            self.total_bets_this_hand[player_index] += contribution
+            self.betting_history.append((str(player_index), ("bet", contribution)))
+            if contribution < blind_amount:
+                self._log(
+                    f"Player {player_index + 1} posts {label} blind of {contribution} chips (all-in)."
+                )
+            else:
+                self._log(
+                    f"Player {player_index + 1} posts {label} blind of {blind_amount} chips."
+                )
+            structured_blind_actions.append((str(player_index), ("bet", contribution)))
+            return contribution
+
         # Small Blind
-        self.player_chips[small_blind_player] -= self.small_blind
-        self.bets[small_blind_player] = self.small_blind
-        self.pot += self.small_blind
-        self.total_bets_this_hand[small_blind_player] += self.small_blind
-        self.betting_history.append((str(small_blind_player), ("bet", self.small_blind)))
-        self._log(f"Player {small_blind_player + 1} posts small blind of {self.small_blind} chips.")
-        structured_blind_actions.append((str(small_blind_player), ("bet", self.small_blind)))
+        _post_blind(small_blind_player, self.small_blind, "small")
 
         # Big Blind
-        self.player_chips[big_blind_player] -= self.big_blind
-        self.bets[big_blind_player] = self.big_blind
-        self.pot += self.big_blind
-        self.total_bets_this_hand[big_blind_player] += self.big_blind
-        self.betting_history.append((str(big_blind_player), ("bet", self.big_blind)))
-        self._log(f"Player {big_blind_player + 1} posts big blind of {self.big_blind} chips.")
-        structured_blind_actions.append((str(big_blind_player), ("bet", self.big_blind)))
+        big_blind_contribution = _post_blind(big_blind_player, self.big_blind, "big")
 
-        self.current_bet = self.big_blind
-        self.previous_raise_amount = self.big_blind
+        self.current_bet = big_blind_contribution
+        self.previous_raise_amount = big_blind_contribution
         self.current_player = (big_blind_player + 1) % self.num_players
         return structured_blind_actions
 

--- a/tests/test_texas_holdem_rules.py
+++ b/tests/test_texas_holdem_rules.py
@@ -23,6 +23,28 @@ def test_post_blinds() -> None:
     assert rules.total_bets_this_hand == [10, 5]
 
 
+def test_post_blinds_short_stacks() -> None:
+    rules = TexasHoldemRules(num_players=2, starting_stack=100)
+    rules.small_blind = 5
+    rules.big_blind = 10
+    rules.player_chips = [7, 3]  # Big blind seat first, then small blind seat
+    rules.bets = [0, 0]
+    rules.total_bets_this_hand = [0, 0]
+
+    structured_actions = rules.post_blinds()
+
+    assert rules.pot == 10
+    assert rules.player_chips == [0, 0]
+    assert rules.bets == [7, 3]
+    assert rules.total_bets_this_hand == [7, 3]
+    assert rules.current_bet == 7
+    assert rules.previous_raise_amount == 7
+    assert structured_actions == [
+        ("1", ("bet", 3)),
+        ("0", ("bet", 7)),
+    ]
+
+
 def test_showdown_awards_blinds() -> None:
     game = TexasHoldem(num_players=2, starting_stack=100, verbose=False)
     game.rules.small_blind = 5


### PR DESCRIPTION
## Summary
- cap blind postings at the chips available so all-in blinds empty the stack without going negative
- update betting state (pot, bets, totals, current bet) to reflect the actual blind contributions
- cover short blind stacks with a regression test that ensures blinds match the available chips

## Testing
- pytest tests/test_texas_holdem_rules.py

------
https://chatgpt.com/codex/tasks/task_b_68cbd274e088832ab8051e1d19b72eb7