### PR TITLE
Fix tournament scoring by tracking per-hand winners

### DIFF
--- a/src/poker_ai/evaluation/performance_analysis.py
+++ b/src/poker_ai/evaluation/performance_analysis.py
@@ -116,13 +116,31 @@ def run_tournament(
                 player_strategies=[strat_i, strat_j],
                 verbose=False,
             )
+            player_paths = [path_i, path_j]
             for _ in range(games_per_match):
+                previous_chips = list(game.rules.player_chips)
                 game.play_game()
-                chips = game.rules.player_chips
-                if chips[0] > chips[1]:
-                    scores[path_i] += 1
-                elif chips[1] > chips[0]:
-                    scores[path_j] += 1
+                updated_chips = list(game.rules.player_chips)
+                deltas = [after - before for before, after in zip(previous_chips, updated_chips)]
+
+                positive_winners = [idx for idx, delta in enumerate(deltas) if delta > 0]
+                winner_index: int | None = None
+
+                if len(positive_winners) == 1:
+                    winner_index = positive_winners[0]
+                elif len(positive_winners) == 0:
+                    winner_info = getattr(game, "last_winner", None)
+                    if isinstance(winner_info, int):
+                        winner_index = winner_info
+                    elif isinstance(winner_info, list) and len(winner_info) == 1:
+                        winner_index = winner_info[0]
+
+                if (
+                    winner_index is not None
+                    and 0 <= winner_index < len(player_paths)
+                    and deltas[winner_index] > 0
+                ):
+                    scores[player_paths[winner_index]] += 1
     return scores
 
 

--- a/tests/test_performance_analysis.py
+++ b/tests/test_performance_analysis.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
@@ -13,7 +14,10 @@ for p in (src_path, project_root):
         sys.path.insert(0, p)
 
 from poker_ai.ai.models.transformer import AdvantageNetwork
-from poker_ai.evaluation.performance_analysis import ModelPerformanceAnalyzer
+from poker_ai.evaluation.performance_analysis import (
+    ModelPerformanceAnalyzer,
+    run_tournament,
+)
 
 
 class DummyTrainer:
@@ -63,6 +67,46 @@ class TestPerformanceAnalyzer(unittest.TestCase):
             )
             analyzer.on_iteration_end(trainer, 1)
             self.assertEqual(os.listdir(tmpdir), [])
+
+    def test_run_tournament_uses_per_hand_winners(self):
+        class DummyEvalStrategy:
+            is_human = False
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+        class DummyGame:
+            def __init__(self, num_players, starting_stack, player_strategies, verbose=False):
+                self.rules = SimpleNamespace(
+                    player_chips=[starting_stack for _ in range(num_players)]
+                )
+                self.hands_played = 0
+                self.last_winner = None
+
+            def play_game(self):
+                if self.hands_played == 0:
+                    self.rules.player_chips[0] += 200
+                    self.rules.player_chips[1] -= 200
+                    self.last_winner = 0
+                elif self.hands_played == 1:
+                    self.rules.player_chips[0] -= 150
+                    self.rules.player_chips[1] += 150
+                    self.last_winner = 1
+                else:
+                    self.last_winner = None
+                self.hands_played += 1
+
+        with patch(
+            "poker_ai.evaluation.performance_analysis.EvalStrategy",
+            DummyEvalStrategy,
+        ), patch(
+            "poker_ai.evaluation.performance_analysis.TexasHoldem",
+            DummyGame,
+        ):
+            scores = run_tournament(["model_a", "model_b"], games_per_match=2)
+
+        self.assertEqual(scores["model_a"], 1)
+        self.assertEqual(scores["model_b"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update tournament scoring to detect each hand's winner via chip deltas and last_winner fallbacks before awarding points
- add a regression test that simulates alternating hand victories to verify both players earn one point

## Testing
- pytest tests/test_performance_analysis.py

------
https://chatgpt.com/codex/tasks/task_b_68cbd273b864832a9d9dca17ef201bc9