### PR TITLE
Fix blind rotation for eliminated players and optimize dealing

### DIFF
--- a/src/poker_ai/engine/texas_holdem.py
+++ b/src/poker_ai/engine/texas_holdem.py
@@ -94,6 +94,29 @@ class TexasHoldemRules:
         ranks = ["2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K", "A"]
         return CardDeck([rank + suit for suit in suits for rank in ranks])
 
+    def _next_player_with_chips(
+        self, start_index: int, *, include_start: bool = False
+    ) -> int | None:
+        """Return the next active seat with chips starting after ``start_index``.
+
+        Eliminated players keep their seat numbers but have ``active_players`` set
+        to ``False`` and their chip stack reduced to zero.  Blinds and action order
+        must therefore skip over such seats when rotating around the table.  The
+        search wraps around at the end of the table and gives up when no eligible
+        player is found.
+        """
+
+        if self.num_players <= 0:
+            return None
+
+        step_start = start_index if include_start else (start_index + 1) % self.num_players
+        idx = step_start
+        for _ in range(self.num_players):
+            if self.active_players[idx] and self.player_chips[idx] > 0:
+                return idx
+            idx = (idx + 1) % self.num_players
+        return None
+
     def shuffle_deck(self):
         # Ensure the deck is actually shuffled
         random.shuffle(self.deck)
@@ -107,12 +130,17 @@ class TexasHoldemRules:
         for _ in range(2):
             for i in range(self.num_players):
                 if self.active_players[i]:
-                    self.hands[i].append(self.deck.pop(0))
+                    self.hands[i].append(self.deck.pop())
 
     def post_blinds(self):
         structured_blind_actions = []
-        small_blind_player = (self.dealer_button + 1) % self.num_players
-        big_blind_player = (self.dealer_button + 2) % self.num_players
+        small_blind_player = self._next_player_with_chips(self.dealer_button)
+        if small_blind_player is None:
+            return []
+
+        big_blind_player = self._next_player_with_chips(small_blind_player)
+        if big_blind_player is None:
+            big_blind_player = small_blind_player
 
         def _post_blind(player_index: int, blind_amount: int, label: str) -> int:
             available_chips = self.player_chips[player_index]
@@ -143,7 +171,11 @@ class TexasHoldemRules:
 
         self.current_bet = big_blind_contribution
         self.previous_raise_amount = big_blind_contribution
-        self.current_player = (big_blind_player + 1) % self.num_players
+
+        next_player = self._next_player_with_chips(big_blind_player)
+        if next_player is None:
+            next_player = big_blind_player
+        self.current_player = next_player
         return structured_blind_actions
 
     def bet(self, player_index, amount):
@@ -214,27 +246,27 @@ class TexasHoldemRules:
     def deal_community_cards(self, round_stage):
         if round_stage == "flop":
             # Burn a card
-            burned = self.deck.pop(0)
+            burned = self.deck.pop()
             self._log(f"Burned a card: {self._format_card(burned)}.")
             # Deal the flop (3 cards)
             for _ in range(3):
-                card = self.deck.pop(0)
+                card = self.deck.pop()
                 self.community_cards.append(card)
                 self._log(f"Dealt community card: {self._format_card(card)}.")
         elif round_stage == "turn":
             # Burn a card
-            burned = self.deck.pop(0)
+            burned = self.deck.pop()
             self._log(f"Burned a card: {self._format_card(burned)}.")
             # Deal the turn (1 card)
-            card = self.deck.pop(0)
+            card = self.deck.pop()
             self.community_cards.append(card)
             self._log(f"Dealt community card: {self._format_card(card)}.")
         elif round_stage == "river":
             # Burn a card
-            burned = self.deck.pop(0)
+            burned = self.deck.pop()
             self._log(f"Burned a card: {self._format_card(burned)}.")
             # Deal the river (1 card)
-            card = self.deck.pop(0)
+            card = self.deck.pop()
             self.community_cards.append(card)
             self._log(f"Dealt community card: {self._format_card(card)}.")
         else:
@@ -937,7 +969,10 @@ class TexasHoldem:
         self.rules.community_cards = []
         self.rules.pot = 0
         self.rules.bets = [0] * self.num_players
-        self.rules.current_player = (self.rules.dealer_button + 1) % self.num_players
+        next_player = self.rules._next_player_with_chips(self.rules.dealer_button)
+        if next_player is None:
+            next_player = self.rules.dealer_button
+        self.rules.current_player = next_player
         self.rules.current_bet = 0
         self.rules.previous_raise_amount = 0
         self.rules.betting_history = []

--- a/tests/test_texas_holdem_rules.py
+++ b/tests/test_texas_holdem_rules.py
@@ -45,6 +45,30 @@ def test_post_blinds_short_stacks() -> None:
     ]
 
 
+def test_post_blinds_skips_eliminated_players() -> None:
+    rules = TexasHoldemRules(num_players=4, starting_stack=100)
+    rules.small_blind = 5
+    rules.big_blind = 10
+    rules.dealer_button = 0
+    rules.player_chips = [100, 0, 0, 50]
+    rules.active_players = [True, False, False, True]
+    rules.bets = [0, 0, 0, 0]
+    rules.total_bets_this_hand = [0, 0, 0, 0]
+
+    structured_actions = rules.post_blinds()
+
+    assert rules.bets == [10, 0, 0, 5]
+    assert rules.player_chips == [90, 0, 0, 45]
+    assert rules.pot == 15
+    assert rules.current_bet == 10
+    assert rules.previous_raise_amount == 10
+    assert rules.current_player == 3
+    assert structured_actions == [
+        ("3", ("bet", 5)),
+        ("0", ("bet", 10)),
+    ]
+
+
 def test_showdown_awards_blinds() -> None:
     game = TexasHoldem(num_players=2, starting_stack=100, verbose=False)
     game.rules.small_blind = 5


### PR DESCRIPTION
## Summary
- ensure blind posting and next-to-act selection skip eliminated players by scanning for the next active seat
- update card dealing to pop from the deck in O(1) time while keeping community dealing consistent
- cover the blind skipping behaviour with a targeted regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cbf1c06d0c832aa6a603e821b94d28