### PR TITLE
Add missing httpx dependency for FastAPI tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
     "eval7>=0.1.10",
     "fastapi>=0.115",
+    "httpx>=0.28",
     "numpy>=1.25",
     "pillow>=10.0",
     "prometheus-client>=0.22",


### PR DESCRIPTION
## Summary
- add httpx to the core project dependencies so FastAPI's TestClient can be imported during tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ccb78a93a8832a82ccdd399ee5c0c7