### PR TITLE
Add TPU training support via torch_xla

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyyaml>=6.0.1",
     "rich>=13.7",
     "torch>=2.2",
+    "torch-xla>=2.2",
     "typer>=0.12.3",
 ]
 

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ To control the computation device you can use:
 
 - `--gpus` to train on available GPUs (uses all GPUs via `DataParallel`).
 - `--npus` to train on available NPUs (uses all NPUs via `DataParallel`).
+- `--tpu` to launch training on a TPU VM using `torch_xla` (mutually exclusive with the flags above).
 
 For faster iteration during small experiments you can lower the minimum replay
 buffer required before training with:
@@ -62,6 +63,30 @@ buffer required before training with:
   have been collected (defaults to 256).
 
 Omitting these flags runs training on the CPU by default.
+
+### TPU training workflow
+
+Running on a Cloud TPU requires a TPU VM environment with the matching
+`torch`/`torch-xla` wheels installed. A typical setup looks like:
+
+1. [Create a TPU VM](https://cloud.google.com/tpu/docs/v4-users-guide#tpu-vm-create).
+2. Install the matching wheels (replace the versions with the release that
+   matches your VM image):
+   ```bash
+   pip install torch==2.2.0 torch-xla==2.2.0 torchvision==0.17.0 -f \
+     https://storage.googleapis.com/tpu-pytorch/wheels/colab.html
+   ```
+3. Clone this repository and install the project dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Run the trainer with TPU support:
+   ```bash
+   python -m poker_ai.cli.train --algorithm deep_cfr --tpu
+   ```
+
+When TPU mode is enabled the tournament evaluations fall back to the CPU so
+that saved checkpoints can still be ranked without XLA kernels.
 
 
 3. **Run tests**:

--- a/requirements.txt
+++ b/requirements.txt
@@ -171,6 +171,8 @@ sympy==1.14.0
     # via torch
 torch==2.8.0
     # via texas-holdem-ai-gatc (pyproject.toml)
+torch-xla==2.2.0
+    # via texas-holdem-ai-gatc (pyproject.toml)
 triton==3.4.0
     # via torch
 typer==0.17.4

--- a/src/poker_ai/ai/trainers/ai_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/ai_cfr_trainer.py
@@ -17,6 +17,16 @@ from poker_ai.ai.models.transformer import AdvantageNetwork
 # CFR utilities live under the package namespace.
 from poker_ai.rules.cfr import calculate_strategy, update_regret, update_strategy
 
+
+def _load_xla_module():
+    try:
+        import torch_xla.core.xla_model as xm  # type: ignore[import-not-found,unused-ignore]
+    except ImportError as exc:  # pragma: no cover - dependency missing
+        raise RuntimeError(
+            "TPU training requested but torch_xla is not installed. Install the torch-xla package."
+        ) from exc
+    return xm
+
 # Load configuration.  If the YAML parser or file is missing we fall back to
 # a small default config so that importing this module never fails.
 try:
@@ -59,9 +69,30 @@ sys.modules[__package__ + ".config"] = config
 
 class AICFRTrainer:
     def __init__(self, device: str | None = None):
-        self.device = (
+        requested_device = (
             device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu")
         )
+        self._xm = None
+        self._xla_device = None
+        if isinstance(requested_device, torch.device) and requested_device.type == "xla":
+            self._xm = _load_xla_module()
+            self._xla_device = requested_device
+        elif isinstance(requested_device, str) and requested_device.startswith("xla"):
+            self._xm = _load_xla_module()
+            ordinal: int | None = None
+            try:
+                _, ordinal_str = requested_device.split(":", 1)
+                ordinal = int(ordinal_str)
+            except (ValueError, IndexError):
+                ordinal = None
+            self._xla_device = (
+                self._xm.xla_device(ordinal) if ordinal is not None else self._xm.xla_device()
+            )
+        if self._xla_device is not None:
+            self.device = self._xla_device
+        else:
+            self.device = requested_device
+        self._using_xla = self._xla_device is not None
         model_config = config.get("model", {})  # Get model sub-config, or empty dict
         hidden_dim = model_config.get("hidden_dim", 128)  # Default if not found
         output_dim = model_config.get("num_actions", 10)  # Default if not found
@@ -117,10 +148,11 @@ class AICFRTrainer:
         if history_tensor.ndim == 2:
             history_tensor = history_tensor.unsqueeze(0)
 
-        hole_summary = hole_summary.to(self.device)
-        community_summary = community_summary.to(self.device)
-        history_tensor = history_tensor.to(self.device)
-        mask = mask.to(self.device) if mask is not None else None
+        target_device = self._xla_device or self.device
+        hole_summary = hole_summary.to(target_device)
+        community_summary = community_summary.to(target_device)
+        history_tensor = history_tensor.to(target_device)
+        mask = mask.to(target_device) if mask is not None else None
 
         with torch.no_grad():
             advantages = self.model(hole_summary, community_summary, history_tensor, src_mask=None)
@@ -158,10 +190,11 @@ class AICFRTrainer:
             if history_tensor.ndim == 2:
                 history_tensor = history_tensor.unsqueeze(0)
 
-            hole_summary = hole_summary.to(self.device)
-            community_summary = community_summary.to(self.device)
-            history_tensor = history_tensor.to(self.device)
-            payoffs = all_counterfactual_payoffs.to(self.device)
+            target_device = self._xla_device or self.device
+            hole_summary = hole_summary.to(target_device)
+            community_summary = community_summary.to(target_device)
+            history_tensor = history_tensor.to(target_device)
+            payoffs = all_counterfactual_payoffs.to(target_device)
 
             logits = self.model(
                 hole_summary,
@@ -173,7 +206,7 @@ class AICFRTrainer:
 
             legal_mask = None
             if mask is not None:
-                legal_mask = mask.to(self.device)
+                legal_mask = mask.to(target_device)
                 if legal_mask.dtype != torch.bool:
                     legal_mask = legal_mask.bool()
                 strategy_pred = torch.where(legal_mask, strategy_pred, torch.zeros_like(strategy_pred))
@@ -189,11 +222,12 @@ class AICFRTrainer:
                 payoffs = torch.where(legal_mask, payoffs, torch.zeros_like(payoffs))
 
             if info_set_id not in self.cumulative_regret:
+                init_device = self._xla_device or self.device
                 self.cumulative_regret[info_set_id] = torch.zeros(
-                    self.num_actions, device=self.device
+                    self.num_actions, device=init_device
                 )
                 self.cumulative_strategy[info_set_id] = torch.zeros(
-                    self.num_actions, device=self.device
+                    self.num_actions, device=init_device
                 )
 
             cumulative_regret = self.cumulative_regret[info_set_id]
@@ -219,7 +253,12 @@ class AICFRTrainer:
 
             self.optimizer.zero_grad()
             loss.backward()
-            self.optimizer.step()
+            if self._using_xla:
+                assert self._xm is not None
+                self._xm.optimizer_step(self.optimizer)
+                self._xm.mark_step()
+            else:
+                self.optimizer.step()
 
             logging.info(f"Training step completed. Loss: {loss.item()}")
             return float(loss.item())
@@ -283,7 +322,12 @@ class AICFRTrainer:
                     "trainer": "ai_cfr",
                 },
             }
-            torch.save(payload, model_path)
+            if self._using_xla:
+                assert self._xm is not None
+                self._xm.save(payload, model_path)
+                self._xm.mark_step()
+            else:
+                torch.save(payload, model_path)
             logging.info(f"Model saved to {model_path}")
         except Exception as e:
             logging.error(f"Error saving model: {str(e)}", exc_info=True)
@@ -291,12 +335,16 @@ class AICFRTrainer:
     def load_model(self):
         # Ensure config path is correct or make it an argument
         try:
+            map_location = self.device
+            if self._using_xla:
+                map_location = "cpu"
             payload = torch.load(
-                config["training"]["save_model_path"], map_location=self.device
+                config["training"]["save_model_path"], map_location=map_location
             )
             state_dict = payload["state_dict"] if isinstance(payload, dict) and "state_dict" in payload else payload
             self.model.load_state_dict(state_dict)
-            self.model.to(self.device)
+            target_device = self._xla_device or self.device
+            self.model.to(target_device)
             self.model.eval()
             logging.info(f"Model loaded from {config['training']['save_model_path']}")
         except Exception as e:

--- a/src/poker_ai/ai/trainers/deep_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/deep_cfr_trainer.py
@@ -17,6 +17,16 @@ import torch
 import torch.optim as optim
 from torch.nn.utils import clip_grad_norm_
 
+
+def _load_xla_module():
+    try:
+        import torch_xla.core.xla_model as xm  # type: ignore[import-not-found,unused-ignore]
+    except ImportError as exc:  # pragma: no cover - dependency missing in CPU/GPU environments
+        raise RuntimeError(
+            "TPU training requested but torch_xla is not installed. Install the torch-xla package."
+        ) from exc
+    return xm
+
 from poker_ai.ai.models.transformer import AdvantageNetwork
 
 
@@ -95,9 +105,30 @@ class DeepCFRTrainer:
         if buffer_capacity is not None:
             replay_buffer_capacity = buffer_capacity
 
-        self.device = device if device is not None else (
-            "cuda" if torch.cuda.is_available() else "cpu"
+        requested_device = (
+            device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu")
         )
+        self._xm = None
+        self._xla_device = None
+        if isinstance(requested_device, torch.device) and requested_device.type == "xla":
+            self._xm = _load_xla_module()
+            self._xla_device = requested_device
+        elif isinstance(requested_device, str) and requested_device.startswith("xla"):
+            self._xm = _load_xla_module()
+            ordinal: int | None = None
+            try:
+                _, ordinal_str = requested_device.split(":", 1)
+                ordinal = int(ordinal_str)
+            except (ValueError, IndexError):
+                ordinal = None
+            self._xla_device = (
+                self._xm.xla_device(ordinal) if ordinal is not None else self._xm.xla_device()
+            )
+        if self._xla_device is not None:
+            self.device = self._xla_device
+        else:
+            self.device = requested_device
+        self._using_xla = self._xla_device is not None
         self.num_actions = num_actions
 
         # Each card summary is encoded as 17 features (13 rank + 4 suit).
@@ -162,10 +193,11 @@ class DeepCFRTrainer:
             if community_summary is not None and community_summary.ndim == 1:
                 community_summary = community_summary.unsqueeze(0)
 
+        target_device = self._xla_device or self.device
         out = self.advantage_net(
-            hole_summary.to(self.device),
-            community_summary.to(self.device),
-            history_tensor.to(self.device),
+            hole_summary.to(target_device),
+            community_summary.to(target_device),
+            history_tensor.to(target_device),
         )
         return out.squeeze(0).detach().cpu()
 
@@ -178,11 +210,12 @@ class DeepCFRTrainer:
 
         holes, communities, histories, regrets, iterations = zip(*batch)
 
-        holes = torch.stack(list(holes)).to(self.device)
-        communities = torch.stack(list(communities)).to(self.device)
-        histories = torch.stack(list(histories)).to(self.device)
-        regrets = torch.stack(list(regrets)).to(self.device)
-        iterations = torch.as_tensor(iterations, dtype=torch.float32, device=self.device).view(-1, 1)
+        target_device = self._xla_device or self.device
+        holes = torch.stack(list(holes)).to(target_device)
+        communities = torch.stack(list(communities)).to(target_device)
+        histories = torch.stack(list(histories)).to(target_device)
+        regrets = torch.stack(list(regrets)).to(target_device)
+        iterations = torch.as_tensor(iterations, dtype=torch.float32, device=target_device).view(-1, 1)
 
         adv_pred = self.advantage_net(holes, communities, histories)
         adv_pred = adv_pred - adv_pred.mean(dim=-1, keepdim=True)
@@ -194,7 +227,12 @@ class DeepCFRTrainer:
         self.optimizer.zero_grad(set_to_none=True)
         weighted_loss.backward()
         clip_grad_norm_(self.advantage_net.parameters(), max_norm=1.0)
-        self.optimizer.step()
+        if self._using_xla:
+            assert self._xm is not None  # for type checkers
+            self._xm.optimizer_step(self.optimizer)
+            self._xm.mark_step()
+        else:
+            self.optimizer.step()
 
         return float(weighted_loss.item())
 
@@ -212,15 +250,24 @@ class DeepCFRTrainer:
                 "trainer": "deep_cfr",
             },
         }
-        torch.save(payload, path)
+        if self._using_xla:
+            assert self._xm is not None
+            self._xm.save(payload, path)
+            self._xm.mark_step()
+        else:
+            torch.save(payload, path)
 
     def load_model(self, path: str) -> None:
-        state = torch.load(path, map_location=self.device)
+        map_location = self.device
+        if self._using_xla:
+            map_location = "cpu"
+        state = torch.load(path, map_location=map_location)
         if isinstance(state, dict) and "state_dict" in state:
             state_dict = state["state_dict"]
         else:
             state_dict = state
         self.advantage_net.load_state_dict(state_dict)
-        self.advantage_net.to(self.device)
+        target_device = self._xla_device or self.device
+        self.advantage_net.to(target_device)
         self.advantage_net.eval()
 

--- a/src/poker_ai/ai/trainers/single_network_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/single_network_cfr_trainer.py
@@ -21,6 +21,16 @@ from poker_ai.ai.models.transformer import AdvantageNetwork
 from poker_ai.rules.cfr import calculate_strategy, update_regret, update_strategy
 
 
+def _load_xla_module():
+    try:
+        import torch_xla.core.xla_model as xm  # type: ignore[import-not-found,unused-ignore]
+    except ImportError as exc:  # pragma: no cover - dependency missing
+        raise RuntimeError(
+            "TPU training requested but torch_xla is not installed. Install the torch-xla package."
+        ) from exc
+    return xm
+
+
 class SingleNetworkCFRTrainer:
     """CFR trainer that uses one network to approximate action regrets."""
 
@@ -32,9 +42,30 @@ class SingleNetworkCFRTrainer:
         lr: float = 1e-3,
         device: str | None = None,
     ) -> None:
-        self.device = (
+        requested_device = (
             device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu")
         )
+        self._xm = None
+        self._xla_device = None
+        if isinstance(requested_device, torch.device) and requested_device.type == "xla":
+            self._xm = _load_xla_module()
+            self._xla_device = requested_device
+        elif isinstance(requested_device, str) and requested_device.startswith("xla"):
+            self._xm = _load_xla_module()
+            ordinal: int | None = None
+            try:
+                _, ordinal_str = requested_device.split(":", 1)
+                ordinal = int(ordinal_str)
+            except (ValueError, IndexError):
+                ordinal = None
+            self._xla_device = (
+                self._xm.xla_device(ordinal) if ordinal is not None else self._xm.xla_device()
+            )
+        if self._xla_device is not None:
+            self.device = self._xla_device
+        else:
+            self.device = requested_device
+        self._using_xla = self._xla_device is not None
 
         # ``AdvantageNetwork`` expects separate history and card summaries.  The
         # simplified single-network approach reuses ``input_feature_dim`` for both
@@ -59,8 +90,9 @@ class SingleNetworkCFRTrainer:
         self.num_layers = 2
         self.max_seq_len = 256
 
-        self.cumulative_regret = torch.zeros(num_actions, device=self.device)
-        self.cumulative_strategy = torch.zeros(num_actions, device=self.device)
+        init_device = self._xla_device or self.device
+        self.cumulative_regret = torch.zeros(num_actions, device=init_device)
+        self.cumulative_strategy = torch.zeros(num_actions, device=init_device)
 
         # Minimal configuration dictionary consumed by ``SelfPlay`` and the
         # evaluation utilities.
@@ -96,14 +128,15 @@ class SingleNetworkCFRTrainer:
         if history_tensor.ndim == 2:
             history_tensor = history_tensor.unsqueeze(0)
 
+        target_device = self._xla_device or self.device
         logits = self.model(
-            hole_summary.to(self.device),
-            community_summary.to(self.device),
-            history_tensor.to(self.device),
+            hole_summary.to(target_device),
+            community_summary.to(target_device),
+            history_tensor.to(target_device),
         ).squeeze(0)
 
         if mask is not None:
-            legal_mask = mask.to(logits.device)
+            legal_mask = mask.to(target_device)
             if legal_mask.dtype != torch.bool:
                 legal_mask = legal_mask.bool()
             logits = torch.where(legal_mask, logits, torch.full_like(logits, -1e9))
@@ -118,10 +151,11 @@ class SingleNetworkCFRTrainer:
         counterfactual_payoffs: torch.Tensor,
         legal_actions_mask: torch.Tensor | None = None,
     ) -> float:
-        hole_summary = hole_summary.to(self.device)
-        community_summary = community_summary.to(self.device)
-        history_tensor = history_tensor.to(self.device)
-        payoffs = counterfactual_payoffs.to(self.device)
+        target_device = self._xla_device or self.device
+        hole_summary = hole_summary.to(target_device)
+        community_summary = community_summary.to(target_device)
+        history_tensor = history_tensor.to(target_device)
+        payoffs = counterfactual_payoffs.to(target_device)
 
         if hole_summary.ndim == 1:
             hole_summary = hole_summary.unsqueeze(0)
@@ -135,7 +169,7 @@ class SingleNetworkCFRTrainer:
 
         mask = None
         if legal_actions_mask is not None:
-            mask = legal_actions_mask.to(self.device)
+            mask = legal_actions_mask.to(target_device)
             if mask.dtype != torch.bool:
                 mask = mask.bool()
             strategy_pred = torch.where(mask, strategy_pred, torch.zeros_like(strategy_pred))
@@ -165,7 +199,12 @@ class SingleNetworkCFRTrainer:
         loss = nn.functional.mse_loss(strategy_pred, target_strategy.detach())
         self.optimizer.zero_grad()
         loss.backward()
-        self.optimizer.step()
+        if self._using_xla:
+            assert self._xm is not None
+            self._xm.optimizer_step(self.optimizer)
+            self._xm.mark_step()
+        else:
+            self.optimizer.step()
         return float(loss.item())
 
     def train(self, batch_size: int = 256) -> float:
@@ -202,16 +241,25 @@ class SingleNetworkCFRTrainer:
                 "trainer": "single_network",
             },
         }
-        torch.save(payload, path)
+        if self._using_xla:
+            assert self._xm is not None
+            self._xm.save(payload, path)
+            self._xm.mark_step()
+        else:
+            torch.save(payload, path)
 
     def load_model(self, path: str) -> None:
-        payload = torch.load(path, map_location=self.device)
+        map_location = self.device
+        if self._using_xla:
+            map_location = "cpu"
+        payload = torch.load(path, map_location=map_location)
         if isinstance(payload, dict) and "state_dict" in payload:
             state_dict = payload["state_dict"]
         else:
             state_dict = payload
         self.model.load_state_dict(state_dict)
-        self.model.to(self.device)
+        target_device = self._xla_device or self.device
+        self.model.to(target_device)
         self.model.eval()
 
 

--- a/src/poker_ai/cli/train.py
+++ b/src/poker_ai/cli/train.py
@@ -56,6 +56,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Use available NPUs. Wraps model in DataParallel if multiple NPUs are present.",
     )
+    parser.add_argument(
+        "--tpu",
+        action="store_true",
+        help="Use a TPU via torch_xla for training.",
+    )
     return parser.parse_args()
 
 
@@ -82,7 +87,7 @@ def initialize_trainer(
     config:
         Loaded configuration dictionary.
     device:
-        The computation device identifier (``cpu``, ``cuda`` or ``npu``).
+        The computation device identifier (``cpu``, ``cuda``, ``npu`` or ``xla``).
     use_data_parallel:
         If ``True`` the underlying model will be wrapped with
         :class:`torch.nn.DataParallel` to leverage multiple devices.
@@ -154,19 +159,36 @@ def main() -> None:  # noqa: C901
     ):
         if isinstance(getattr(args, attr, None), MagicMock):
             setattr(args, attr, None)
-    for flag in ("gpus", "npus"):
+    for flag in ("gpus", "npus", "tpu"):
         if isinstance(getattr(args, flag, None), MagicMock):
             setattr(args, flag, False)
 
     device: str = "cpu"
     use_data_parallel = False
+    device_printable = device
+
+    if args.tpu and (args.gpus or args.npus):
+        raise ValueError("Cannot specify --tpu with --gpus or --npus.")
 
     if args.gpus and args.npus:
         raise ValueError("Cannot specify both --gpus and --npus.")
 
-    if args.npus:
+    if args.tpu:
+        try:
+            import torch_xla.core.xla_model as xm  # type: ignore[attr-defined]
+        except ImportError as exc:  # pragma: no cover - dependency not installed
+            raise RuntimeError(
+                "torch_xla is required for TPU training. Install the torch-xla package first."
+            ) from exc
+
+        xla_device = xm.xla_device()
+        device = "xla"
+        device_printable = f"{device} ({xla_device})"
+        print(f"TPU training enabled on device {xla_device}.")
+    elif args.npus:
         if hasattr(torch, "npu") and torch.npu.is_available():
             device = "npu"
+            device_printable = device
             npu_count = torch.npu.device_count()
             if npu_count > 1:
                 use_data_parallel = True
@@ -181,6 +203,7 @@ def main() -> None:  # noqa: C901
     elif args.gpus:
         if torch.cuda.is_available():
             device = "cuda"
+            device_printable = device
             gpu_count = torch.cuda.device_count()
             if gpu_count > 1:
                 use_data_parallel = True
@@ -192,6 +215,10 @@ def main() -> None:  # noqa: C901
                 "Warning: --gpus specified, but no GPU devices are available. "
                 "Falling back to CPU."
             )
+
+    analyzer_device = device if device != "xla" else "cpu"
+    if device == "xla" and analyzer_device == "cpu":
+        print("ModelPerformanceAnalyzer evaluations will run on the CPU while training on TPU.")
 
     # Load configuration
     config = load_configuration(args.config)
@@ -255,7 +282,7 @@ def main() -> None:  # noqa: C901
     print(f"Players per hand: random {min_players}-{max_players}")
     print(f"Starting stack: {starting_stack}")
     print(f"Blinds: SB={small_blind}, BB={big_blind}")
-    print(f"Using device: {device}")
+    print(f"Using device: {device_printable}")
     print(f"Min buffer before training: {min_buffer_before_train}")
 
     # Initialization
@@ -272,7 +299,10 @@ def main() -> None:  # noqa: C901
         cfr_trainer = cast(
             Any,
             initialize_trainer(
-                args.algorithm, config, device, use_data_parallel=use_data_parallel
+                args.algorithm,
+                config,
+                device,
+                use_data_parallel=use_data_parallel,
             ),
         )
         print(f"{args.algorithm} trainer initialized.")
@@ -297,7 +327,7 @@ def main() -> None:  # noqa: C901
         models_dir="models",
         save_every_iterations=save_model_every_samples,
         tournament_threshold=10,
-        device=device,
+        device=analyzer_device,
     )
 
     last_save_time = time.time()


### PR DESCRIPTION
## Summary
- add a `--tpu` flag to the training CLI, selecting an XLA device when requested and falling back to CPU for tournament analysis
- extend all CFR trainers to resolve XLA devices, move tensors appropriately, and use `xm.optimizer_step`/`xm.save` when running on TPU
- document TPU setup, add the torch-xla dependency, and ensure saved checkpoints persist when training on Cloud TPU

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68ccbed7922c832a909451f934a84a53