### PR TITLE
Fix monitoring health helper missing imports

### DIFF
--- a/src/poker_ai/monitoring/health.py
+++ b/src/poker_ai/monitoring/health.py
@@ -1,11 +1,16 @@
+"""Health monitoring helpers for training stability checks."""
+
+from __future__ import annotations
+
 import math
 from typing import Any, Iterable, Optional
 
 try:
     import torch
+
     _HAS_TORCH = True
-except Exception:
-    torch = None
+except Exception:  # pragma: no cover - torch optional dependency
+    torch = None  # type: ignore[assignment]
     _HAS_TORCH = False
 
 


### PR DESCRIPTION
## Summary
- ensure the monitoring health helpers declare required imports
- keep the optional torch dependency guarded while documenting the module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cccb420c14832aa7e15e48dc1c6b06