### PR TITLE
Fix side pot computation with folded contributions

### DIFF
--- a/gatc_holdem/engine/rules.py
+++ b/gatc_holdem/engine/rules.py
@@ -77,9 +77,14 @@ def build_side_pots(contributions: list[int], in_hand: list[bool]) -> list[Pot]:
     prev = 0
     for level in levels:
         delta = level - prev
-        eligible = [i for i, c in enumerate(contributions) if c >= level and in_hand[i]]
+        if delta <= 0:
+            prev = level
+            continue
+
+        contributors = [i for i, c in enumerate(contributions) if c >= level]
+        eligible = [i for i in contributors if in_hand[i]]
         if len(eligible) >= 2:
-            amount = delta * len(eligible)
+            amount = delta * len(contributors)
             pots.append(Pot(amount=amount, eligible=tuple(eligible)))
         prev = level
     return pots

--- a/tests/test_sidepots.py
+++ b/tests/test_sidepots.py
@@ -22,8 +22,11 @@ def test_folded_players_not_eligible_in_side_pots() -> None:
     pots = build_side_pots(contrib, in_hand)
     # levels: 200 (eligible 0,1), 1000 (eligible 0,1) => two pots
     assert len(pots) == 2
-    assert pots[0].amount == 400 and set(pots[0].eligible) == {0, 1}
+    # Folded player's 200 chips still contribute to the main pot contested
+    # between the remaining players.
+    assert pots[0].amount == 600 and set(pots[0].eligible) == {0, 1}
     assert pots[1].amount == 1600 and set(pots[1].eligible) == {0, 1}
+    assert sum(p.amount for p in pots) == sum(contrib)
 
 
 def test_odd_chip_goes_left_of_button_among_winners() -> None:


### PR DESCRIPTION
## Summary
- ensure folded players' committed chips contribute to side pots in build_side_pots
- adjust side pot test to verify folded contributions remain in play

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68ccce370530832a9012f4b53768e2df