### PR TITLE
Add periodic model saving to simple training loop

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -11,6 +11,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--num-hands", type=int, default=100, help="Number of hands to simulate")
     parser.add_argument("--num-players", type=int, default=2, help="Number of players at the table")
     parser.add_argument("--starting-stack", type=int, default=1000, help="Starting chip stack")
+    parser.add_argument(
+        "--save-interval",
+        type=int,
+        default=0,
+        help=(
+            "Number of hands between intermediate model saves. "
+            "A value of 0 disables periodic saving."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -24,8 +33,10 @@ def main() -> None:
     trainer = AICFRTrainer()
     self_play_env = SelfPlay(cfr_trainer=trainer, game_engine_config=game_cfg)
 
-    for _ in range(args.num_hands):
+    for hand_idx in range(1, args.num_hands + 1):
         self_play_env.play_hand_for_training()
+        if args.save_interval and hand_idx % args.save_interval == 0:
+            trainer.save_model()
     trainer.save_model()
 
 


### PR DESCRIPTION
## Summary
- add a command-line option for the simple training script to control periodic model saves
- trigger trainer.save_model at the configured hand interval during self-play
- retain a final save after completing all requested hands

## Testing
- python -m compileall training/train.py

------
https://chatgpt.com/codex/tasks/task_b_68cd89e1605c832ab5cd643e19055bcb