### PR TITLE
Scale transformer defaults for near-GTO training

### DIFF
--- a/models/opponent_model.py
+++ b/models/opponent_model.py
@@ -12,7 +12,7 @@ class OpponentModel(nn.Module):
             input_feature_dim=input_feature_dim,
             hidden_dim=hidden_dim,
             num_heads=4,
-            num_layers=2,
+            num_layers=4,
             num_actions=num_actions,
         )
 

--- a/src/poker_ai/ai/model_loader.py
+++ b/src/poker_ai/ai/model_loader.py
@@ -36,9 +36,17 @@ def load_model_strategy(
         except (KeyError, TypeError, ValueError) as exc:
             raise ValueError(f"Invalid model metadata: {exc}") from exc
 
-        hidden_dim = int(metadata_obj.get("hidden_dim", 128))
-        num_heads = int(metadata_obj.get("num_heads", 4))
-        num_layers = int(metadata_obj.get("num_layers", 2))
+        hidden_dim = int(
+            metadata_obj.get("hidden_dim", AdvantageNetwork.DEFAULT_HIDDEN_DIM)
+        )
+        num_heads_value = metadata_obj.get("num_heads")
+        if num_heads_value is None:
+            num_heads = AdvantageNetwork.recommended_num_heads(hidden_dim)
+        else:
+            num_heads = int(num_heads_value)
+        num_layers = int(
+            metadata_obj.get("num_layers", AdvantageNetwork.DEFAULT_NUM_LAYERS)
+        )
         max_seq_len = int(metadata_obj.get("max_seq_len", 256))
 
         state_dict = payload.get("state_dict")

--- a/src/poker_ai/ai/models/transformer.py
+++ b/src/poker_ai/ai/models/transformer.py
@@ -14,7 +14,38 @@ class AdvantageNetwork(nn.Module):
     The card summaries are projected and concatenated with a pooled
     representation of ``history_seq`` before the final linear layer outputs the
     advantages for each abstract action.
+
+    ``DEFAULT_NUM_LAYERS`` exposes the project's canonical transformer depth so
+    that other modules can adopt the same default without duplicating literals.
+    Updating the default depth in this module automatically informs all callers
+    that reference the attribute.
     """
+
+    DEFAULT_NUM_LAYERS = 12
+    DEFAULT_HIDDEN_DIM = 768
+    DEFAULT_NUM_HEADS = 12
+
+    @staticmethod
+    def recommended_num_heads(
+        hidden_dim: int, preferred: int | None = None
+    ) -> int:
+        """Return a head count that evenly divides ``hidden_dim``.
+
+        When loading legacy checkpoints that do not record the original head
+        count, callers can request the highest divisor up to ``preferred``.
+        ``preferred`` defaults to :data:`DEFAULT_NUM_HEADS`, ensuring the
+        transformer remains compatible with historical smaller models while
+        using twelve heads for the new XL configuration.
+        """
+
+        target = preferred or AdvantageNetwork.DEFAULT_NUM_HEADS
+        if hidden_dim <= 0:
+            return 1
+        target = min(target, hidden_dim)
+        for candidate in range(target, 0, -1):
+            if hidden_dim % candidate == 0:
+                return candidate
+        return 1
 
     def __init__(
         self,

--- a/src/poker_ai/ai/trainers/ai_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/ai_cfr_trainer.py
@@ -44,11 +44,13 @@ except Exception:
     config = {
         "logging": {"log_file": "aicfr_trainer.log"},
         "model": {
-            "hidden_dim": 128,
+            "hidden_dim": 768,
             "num_actions": 10,
             "learning_rate": 0.001,
             "d_raw_feature": 18,
             "max_seq_len": 256,
+            "num_layers": AdvantageNetwork.DEFAULT_NUM_LAYERS,
+            "num_heads": AdvantageNetwork.DEFAULT_NUM_HEADS,
         },
         "training": {"save_model_path": "aicfr_model.pth"},
     }
@@ -94,17 +96,25 @@ class AICFRTrainer:
             self.device = requested_device
         self._using_xla = self._xla_device is not None
         model_config = config.get("model", {})  # Get model sub-config, or empty dict
-        hidden_dim = model_config.get("hidden_dim", 128)  # Default if not found
-        output_dim = model_config.get("num_actions", 10)  # Default if not found
-        learning_rate = model_config.get("learning_rate", 0.001)  # Default if not found
+        hidden_dim = int(
+            model_config.get("hidden_dim", AdvantageNetwork.DEFAULT_HIDDEN_DIM)
+        )
+        output_dim = int(model_config.get("num_actions", 10))
+        learning_rate = float(model_config.get("learning_rate", 0.001))
 
         # Feature dimensions for history sequence and card set summaries
         d_raw_feature = model_config.get("d_raw_feature", 18)
         d_card_feature = model_config.get("d_card_feature", 17)
 
         self.hidden_dim = hidden_dim
-        self.num_heads = model_config.get("num_heads", 8)
-        self.num_layers = model_config.get("num_layers", 2)
+        num_heads_config = model_config.get("num_heads")
+        if num_heads_config is None:
+            self.num_heads = AdvantageNetwork.recommended_num_heads(hidden_dim)
+        else:
+            self.num_heads = int(num_heads_config)
+        self.num_layers = int(
+            model_config.get("num_layers", AdvantageNetwork.DEFAULT_NUM_LAYERS)
+        )
 
         self.model = AdvantageNetwork(
             history_feature_dim=d_raw_feature,

--- a/src/poker_ai/ai/trainers/deep_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/deep_cfr_trainer.py
@@ -135,8 +135,8 @@ class DeepCFRTrainer:
         self.card_feature_dim = 17
         self.history_feature_dim = input_feature_dim
         self.hidden_dim = hidden_dim
-        self.num_heads = 4
-        self.num_layers = 2
+        self.num_heads = AdvantageNetwork.recommended_num_heads(hidden_dim)
+        self.num_layers = AdvantageNetwork.DEFAULT_NUM_LAYERS
         self.max_seq_len = 256
 
         self.advantage_net = AdvantageNetwork(

--- a/src/poker_ai/ai/trainers/single_network_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/single_network_cfr_trainer.py
@@ -74,20 +74,21 @@ class SingleNetworkCFRTrainer:
         # Hole and community summaries are encoded with 17 features (13 ranks +
         # 4 suits) in :func:`prepare_transformer_input`.
         self.card_feature_dim = 17
+        inferred_heads = AdvantageNetwork.recommended_num_heads(hidden_dim)
         self.model = AdvantageNetwork(
             history_feature_dim=self.history_feature_dim,
             card_feature_dim=self.card_feature_dim,
             hidden_dim=hidden_dim,
-            num_heads=4,
-            num_layers=2,
+            num_heads=inferred_heads,
+            num_layers=AdvantageNetwork.DEFAULT_NUM_LAYERS,
             num_actions=num_actions,
         ).to(self.device)
 
         self.optimizer = optim.Adam(self.model.parameters(), lr=lr)
         self.num_actions = num_actions
         self.hidden_dim = hidden_dim
-        self.num_heads = 4
-        self.num_layers = 2
+        self.num_heads = inferred_heads
+        self.num_layers = AdvantageNetwork.DEFAULT_NUM_LAYERS
         self.max_seq_len = 256
 
         init_device = self._xla_device or self.device

--- a/src/poker_ai/cli/play_vs_ai.py
+++ b/src/poker_ai/cli/play_vs_ai.py
@@ -95,14 +95,12 @@ class AIStrategy(PlayerStrategy):
             base.setdefault("num_layers", len(layer_indices))
 
         if "num_layers" not in base:
-            base["num_layers"] = 2
+            base["num_layers"] = AdvantageNetwork.DEFAULT_NUM_LAYERS
 
         if "num_heads" not in base:
-            for candidate in (8, 6, 5, 4, 3, 2):
-                if base["hidden_dim"] % candidate == 0:
-                    base["num_heads"] = candidate
-                    break
-            base.setdefault("num_heads", 1)
+            base["num_heads"] = AdvantageNetwork.recommended_num_heads(
+                base["hidden_dim"]
+            )
 
         base.setdefault("max_seq_len", 256)
         base.setdefault("d_raw_feature", base["history_feature_dim"])

--- a/src/poker_ai/cli/self_play.py
+++ b/src/poker_ai/cli/self_play.py
@@ -131,9 +131,9 @@ def initialize_new_model(device):
     model_config = {
         "history_feature_dim": 18,
         "card_feature_dim": 17,
-        "hidden_dim": 128,
-        "num_heads": 2,
-        "num_layers": 2,
+        "hidden_dim": AdvantageNetwork.DEFAULT_HIDDEN_DIM,
+        "num_heads": AdvantageNetwork.DEFAULT_NUM_HEADS,
+        "num_layers": AdvantageNetwork.DEFAULT_NUM_LAYERS,
         "num_actions": 10,
         "max_seq_len": 256,
         "d_raw_feature": 18,
@@ -206,9 +206,15 @@ def _metadata_from_config(config_dict: Mapping[str, Any]) -> dict[str, Any]:
         )
     )
     card = int(config_dict.get("card_feature_dim", config_dict.get("d_card_feature", 17)))
-    hidden = int(config_dict.get("hidden_dim", 128))
-    num_heads = int(config_dict.get("num_heads", 2))
-    num_layers = int(config_dict.get("num_layers", 2))
+    hidden = int(config_dict.get("hidden_dim", AdvantageNetwork.DEFAULT_HIDDEN_DIM))
+    num_heads_value = config_dict.get("num_heads")
+    if num_heads_value is None:
+        num_heads = AdvantageNetwork.recommended_num_heads(hidden)
+    else:
+        num_heads = int(num_heads_value)
+    num_layers = int(
+        config_dict.get("num_layers", AdvantageNetwork.DEFAULT_NUM_LAYERS)
+    )
     num_actions = int(config_dict.get("num_actions", 10))
     max_seq_len = int(config_dict.get("max_seq_len", 256))
 
@@ -260,9 +266,17 @@ def _normalize_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
         raise ValueError("Invalid model metadata: missing num_actions") from exc
 
     card_feature_dim = int(metadata.get("card_feature_dim", history_feature_dim))
-    hidden_dim = int(metadata.get("hidden_dim", 128))
-    num_heads = int(metadata.get("num_heads", 4))
-    num_layers = int(metadata.get("num_layers", 2))
+    hidden_dim = int(
+        metadata.get("hidden_dim", AdvantageNetwork.DEFAULT_HIDDEN_DIM)
+    )
+    num_heads_value = metadata.get("num_heads")
+    if num_heads_value is None:
+        num_heads = AdvantageNetwork.recommended_num_heads(hidden_dim)
+    else:
+        num_heads = int(num_heads_value)
+    num_layers = int(
+        metadata.get("num_layers", AdvantageNetwork.DEFAULT_NUM_LAYERS)
+    )
     max_seq_len = int(metadata.get("max_seq_len", 256))
 
     normalized = dict(metadata)

--- a/src/poker_ai/cli/train.py
+++ b/src/poker_ai/cli/train.py
@@ -7,6 +7,8 @@ from typing import Any, cast
 
 import torch
 
+from poker_ai.ai.models.transformer import AdvantageNetwork
+
 from poker_ai.config import load_config
 from poker_ai.evaluation.performance_analysis import ModelPerformanceAnalyzer
 
@@ -105,10 +107,10 @@ def initialize_trainer(
         # the configuration file cannot be loaded (e.g. when PyYAML is not
         # installed).  Using a smaller default previously resulted in repeated
         # warnings from ``prepare_transformer_input``.
-        d_raw = model_cfg.get("d_raw_feature", 18)
-        hidden = model_cfg.get("hidden_dim", 128)
-        num_actions = model_cfg.get("num_actions", 10)
-        lr = model_cfg.get("learning_rate", 1e-3)
+        d_raw = int(model_cfg.get("d_raw_feature", 18))
+        hidden = int(model_cfg.get("hidden_dim", AdvantageNetwork.DEFAULT_HIDDEN_DIM))
+        num_actions = int(model_cfg.get("num_actions", 10))
+        lr = float(model_cfg.get("learning_rate", 1e-3))
         trainer = DeepCFRTrainer(d_raw, hidden, num_actions, learning_rate=lr, device=device)
     elif algorithm == "single_network":
         from poker_ai.ai.trainers.single_network_cfr_trainer import SingleNetworkCFRTrainer
@@ -116,10 +118,10 @@ def initialize_trainer(
         model_cfg = config.get("model", {})
         # Match the default described above for Deep CFR to ensure consistent
         # feature dimensions across training approaches.
-        d_raw = model_cfg.get("d_raw_feature", 18)
-        hidden = model_cfg.get("hidden_dim", 128)
-        num_actions = model_cfg.get("num_actions", 10)
-        lr = model_cfg.get("learning_rate", 1e-3)
+        d_raw = int(model_cfg.get("d_raw_feature", 18))
+        hidden = int(model_cfg.get("hidden_dim", AdvantageNetwork.DEFAULT_HIDDEN_DIM))
+        num_actions = int(model_cfg.get("num_actions", 10))
+        lr = float(model_cfg.get("learning_rate", 1e-3))
         trainer = SingleNetworkCFRTrainer(d_raw, hidden, num_actions, lr, device=device)
     else:
         raise ValueError(f"Unknown algorithm: {algorithm}")

--- a/src/poker_ai/config/config.yaml
+++ b/src/poker_ai/config/config.yaml
@@ -27,7 +27,9 @@ model:
   directory: "trained_models/"
   filename_prefix: "cfr_model"
   # Parameters for TransformerAverageStrategy (used by AICFRTrainer)
-  hidden_dim: 128
+  hidden_dim: 768
+  num_heads: 12
+  num_layers: 12
   num_actions: 10 # Should match the game's action space
   d_raw_feature: 18 # Updated to match one-hot card encoding output
 

--- a/src/poker_ai/config/loader.py
+++ b/src/poker_ai/config/loader.py
@@ -30,9 +30,11 @@ _FALLBACK_CONFIG: dict[str, Any] = {
     "model": {
         "directory": "trained_models/",
         "filename_prefix": "cfr_model",
-        "hidden_dim": 128,
+        "hidden_dim": 768,
         "num_actions": 10,
         "d_raw_feature": 18,
+        "num_layers": 12,
+        "num_heads": 12,
     },
     "player_strategies": ["cfr_trained", "random"],
     "simulation": {

--- a/src/poker_ai/evaluation/performance_analysis.py
+++ b/src/poker_ai/evaluation/performance_analysis.py
@@ -35,9 +35,17 @@ class EvalStrategy(PlayerStrategy):
         self.config: dict[str, object] = dict(metadata)
         self.history_feature_dim = int(metadata.get("history_feature_dim", 18))  # type: ignore[arg-type]
         self.card_feature_dim = int(metadata.get("card_feature_dim", self.history_feature_dim))  # type: ignore[arg-type]
-        hidden_dim = int(metadata.get("hidden_dim", 128))  # type: ignore[arg-type]
-        num_heads = int(metadata.get("num_heads", 4))  # type: ignore[arg-type]
-        num_layers = int(metadata.get("num_layers", 2))  # type: ignore[arg-type]
+        hidden_dim = int(
+            metadata.get("hidden_dim", AdvantageNetwork.DEFAULT_HIDDEN_DIM)
+        )  # type: ignore[arg-type]
+        num_heads_raw = metadata.get("num_heads")
+        if num_heads_raw is None:
+            num_heads = AdvantageNetwork.recommended_num_heads(hidden_dim)
+        else:
+            num_heads = int(num_heads_raw)
+        num_layers = int(
+            metadata.get("num_layers", AdvantageNetwork.DEFAULT_NUM_LAYERS)
+        )  # type: ignore[arg-type]
         self.num_actions = int(metadata.get("num_actions", 10))  # type: ignore[arg-type]
         self.max_seq_len = int(metadata.get("max_seq_len", 256))  # type: ignore[arg-type]
 

--- a/tests/test_inference_multi_npu.py
+++ b/tests/test_inference_multi_npu.py
@@ -26,7 +26,7 @@ class TestInferenceMultiNPU(unittest.TestCase):
             card_feature_dim=18,
             hidden_dim=128,
             num_heads=4,
-            num_layers=2,
+            num_layers=AdvantageNetwork.DEFAULT_NUM_LAYERS,
             num_actions=10,
         ).state_dict()
 

--- a/tests/test_model_forward_pass.py
+++ b/tests/test_model_forward_pass.py
@@ -22,7 +22,7 @@ def test_advantage_network_forward_pass():
     hidden_dim = 128
     num_actions = 10
     num_heads = 4
-    num_layers = 2
+    num_layers = AdvantageNetwork.DEFAULT_NUM_LAYERS
 
     # Input tensor parameters
     max_seq_len = 20

--- a/tests/test_performance_analysis.py
+++ b/tests/test_performance_analysis.py
@@ -27,7 +27,7 @@ class DummyTrainer:
             card_feature_dim=18,
             hidden_dim=128,
             num_heads=4,
-            num_layers=2,
+            num_layers=AdvantageNetwork.DEFAULT_NUM_LAYERS,
             num_actions=10,
         )
 


### PR DESCRIPTION
## Summary
- enlarge the AdvantageNetwork defaults to a 12-layer, 768-wide, 12-head transformer and expose a helper to infer compatible head counts
- propagate the XL configuration through configs, trainers, loaders, and CLI utilities while normalizing metadata when models omit their head count
- align evaluation helpers to derive transformer heads from saved metadata so legacy checkpoints stay loadable

## Testing
- pytest tests/test_model_forward_pass.py tests/test_performance_analysis.py tests/test_inference_multi_npu.py tests/test_model_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68cfe9b986e0832aa909d84ecda962f2