### PR TITLE
Load latest model for self-play and human vs AI

### DIFF
--- a/src/poker_ai/cli/play.py
+++ b/src/poker_ai/cli/play.py
@@ -14,6 +14,7 @@ from poker_ai.gui.playStrategy import (
     ModelAIStrategy,
     RandomAIStrategy,
 )
+from poker_ai.utils.model_paths import find_latest_model_checkpoint
 
 
 def parse_args() -> argparse.Namespace:
@@ -40,11 +41,15 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_model(model_path: str) -> ModelAIStrategy | None:
+def load_model(model_path: str | None) -> ModelAIStrategy | None:
     """Load a saved AI model using :func:`load_model_strategy`."""
+
+    if model_path is None:
+        return None
 
     strategy, _ = load_model_strategy(model_path)
     if isinstance(strategy, ModelAIStrategy):
+        print(f"Loaded AI model from {model_path}\n")
         return strategy
     return None
 
@@ -55,7 +60,28 @@ def main() -> None:  # noqa: C901
 
     cfg = load_config(args.config)
 
-    model_strategy = load_model(args.model_path) if args.model_path else None
+    model_path = args.model_path
+    latest: tuple[str, float] | None = None
+    if model_path is None:
+        latest = find_latest_model_checkpoint()
+        if latest is not None:
+            model_path, _ = latest
+            print(f"Using latest available AI model at {model_path}\n")
+        else:
+            print("No saved AI model found. AI players will use random decisions.\n")
+
+    model_strategy = load_model(model_path)
+    if model_strategy is None and model_path is not None:
+        if args.model_path:
+            print(
+                f"Failed to load model from {model_path}. "
+                "Falling back to random AI players.\n"
+            )
+        elif latest is not None:
+            print(
+                f"The detected AI model at {model_path} could not be loaded. "
+                "Using random AI players instead.\n"
+            )
 
     total_players = args.total_players
     if total_players is None:

--- a/src/poker_ai/cli/self_play.py
+++ b/src/poker_ai/cli/self_play.py
@@ -25,6 +25,7 @@ from poker_ai.utils.state_representation import (
     infer_normalization_scale,
     prepare_transformer_input,
 )
+from poker_ai.utils.model_paths import find_latest_model_checkpoint
 
 
 class TransformerStrategy:
@@ -93,17 +94,31 @@ def parse_args():
 
 def load_transformer_model(cfg):
     model_name = cfg.get("model", {}).get("name", "texas_holdem_transformer_ai")
-    weights_path = get_model_path(model_name)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    if os.path.exists(weights_path):
+    default_path = get_model_path(model_name)
+
+    candidate_path: str | None = None
+    last_mtime: float | None = None
+
+    if os.path.exists(default_path):
+        candidate_path = default_path
+        last_mtime = os.path.getmtime(default_path)
+    else:
+        latest = find_latest_model_checkpoint(prefix=model_name)
+        if latest is None:
+            latest = find_latest_model_checkpoint()
+        if latest is not None:
+            candidate_path, last_mtime = latest
+
+    if candidate_path is not None:
         try:
-            strategy = load_existing_model(weights_path, device)
-            last_mtime = os.path.getmtime(weights_path)
-            return strategy, weights_path, last_mtime
+            strategy = load_existing_model(candidate_path, device)
+            return strategy, candidate_path, last_mtime
         except Exception as exc:  # pragma: no cover - defensive logging
             print(f"Failed to load existing model: {exc}. Initializing a new model.")
+
     strategy = initialize_new_model(device)
-    return strategy, weights_path, None
+    return strategy, default_path, None
 
 
 def get_model_path(model_name):
@@ -180,22 +195,33 @@ def save_weights(transformer_strategy, weight_path):
 
 
 def reload_weights_if_updated(transformer_strategy, weights_path, last_mtime):
-    """Reload model weights if the file at ``weights_path`` changed."""
-    if os.path.exists(weights_path):
-        current_mtime = os.path.getmtime(weights_path)
-        if last_mtime is None or current_mtime > last_mtime:
-            try:
-                metadata, state = _load_state_and_metadata(weights_path, transformer_strategy.device)
-                transformer_strategy.model.load_state_dict(state)
-                transformer_strategy.config.update(metadata)
-                print(
-                    f"[Model Reloaded] {datetime.now().isoformat()} - "
-                    f"Loaded weights from {weights_path}"
-                )
-                return current_mtime
-            except Exception as e:
-                print(f"[Model Reloaded] Failed to reload weights: {e}")
-    return last_mtime
+    """Reload to the most recent checkpoint if a newer file is available."""
+    latest = find_latest_model_checkpoint()
+    if latest is None:
+        return weights_path, last_mtime
+
+    latest_path, latest_mtime = latest
+    should_reload = (
+        weights_path != latest_path
+        or last_mtime is None
+        or latest_mtime > last_mtime
+    )
+
+    if not should_reload:
+        return weights_path, last_mtime
+
+    try:
+        metadata, state = _load_state_and_metadata(latest_path, transformer_strategy.device)
+        transformer_strategy.model.load_state_dict(state)
+        transformer_strategy.config.update(metadata)
+        print(
+            f"[Model Reloaded] {datetime.now().isoformat()} - "
+            f"Loaded weights from {latest_path}"
+        )
+        return latest_path, latest_mtime
+    except Exception as e:
+        print(f"[Model Reloaded] Failed to reload weights: {e}")
+        return weights_path, last_mtime
 
 
 def _metadata_from_config(config_dict: Mapping[str, Any]) -> dict[str, Any]:
@@ -379,7 +405,9 @@ def main():
 
     print("Starting self-play simulation. Press Ctrl+C to terminate.")
     while True:
-        last_mtime = reload_weights_if_updated(transformer_strategy, weights_path, last_mtime)
+        weights_path, last_mtime = reload_weights_if_updated(
+            transformer_strategy, weights_path, last_mtime
+        )
         simulate_game(transformer_strategy)
         time.sleep(1)
 

--- a/src/poker_ai/utils/model_paths.py
+++ b/src/poker_ai/utils/model_paths.py
@@ -1,0 +1,62 @@
+"""Utilities for discovering saved model checkpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from poker_ai.config import MODEL_DIR
+
+__all__ = ["find_latest_model_checkpoint"]
+
+
+def _iter_checkpoint_files(directory: Path) -> list[Path]:
+    """Yield checkpoint files within ``directory`` sorted by modification time."""
+
+    if not directory.exists():
+        return []
+
+    files = [
+        entry
+        for entry in directory.iterdir()
+        if entry.is_file() and entry.suffix == ".pth"
+    ]
+    files.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    return files
+
+
+def find_latest_model_checkpoint(
+    directory: str | Path | None = None, prefix: str | None = None
+) -> tuple[str, float] | None:
+    """Return the newest ``.pth`` checkpoint path under ``directory``.
+
+    Parameters
+    ----------
+    directory:
+        Directory to scan for model checkpoints. Defaults to
+        :data:`poker_ai.config.MODEL_DIR`.
+    prefix:
+        Optional filename prefix filter. If provided, only files whose names
+        start with ``prefix`` are considered.
+
+    Returns
+    -------
+    tuple[str, float] | None
+        The path to the newest checkpoint and its modification time. ``None``
+        if no suitable checkpoint exists.
+    """
+
+    root = Path(directory or MODEL_DIR)
+
+    candidates = _iter_checkpoint_files(root)
+    if prefix is not None:
+        candidates = [path for path in candidates if path.name.startswith(prefix)]
+
+    for path in candidates:
+        stat = path.stat()
+        return str(path), stat.st_mtime
+
+    if prefix is not None:
+        # Retry without prefix filtering when no matching file exists.
+        return find_latest_model_checkpoint(directory=root, prefix=None)
+
+    return None

--- a/tests/gui/test_gui_human_vs_ai.py
+++ b/tests/gui/test_gui_human_vs_ai.py
@@ -1,0 +1,35 @@
+"""Pytest-compatible wrapper around the legacy GUI human-vs-AI smoke tests."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+LEGACY_TEST_PATH = Path(__file__).resolve().parents[2] / "test_gui_human_vs_ai.py"
+
+
+def _load_legacy_module() -> ModuleType:
+    """Load the legacy stand-alone test script as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "legacy_gui_human_vs_ai", LEGACY_TEST_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load legacy test module at {LEGACY_TEST_PATH!s}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+LEGACY_MODULE = _load_legacy_module()
+
+
+def test_human_vs_ai_setup() -> None:
+    LEGACY_MODULE.test_human_vs_ai_setup()
+
+
+def test_invalid_setups() -> None:
+    LEGACY_MODULE.test_invalid_setups()
+
+
+def test_turn_management() -> None:
+    LEGACY_MODULE.test_turn_management()

--- a/tests/test_gui_human_vs_ai.py
+++ b/tests/test_gui_human_vs_ai.py
@@ -1,0 +1,20 @@
+"""Compatibility entrypoint so `pytest tests/test_gui_human_vs_ai.py` just works."""
+from __future__ import annotations
+
+from tests.gui.test_gui_human_vs_ai import (
+    test_human_vs_ai_setup as _test_human_vs_ai_setup,
+    test_invalid_setups as _test_invalid_setups,
+    test_turn_management as _test_turn_management,
+)
+
+
+def test_human_vs_ai_setup() -> None:
+    _test_human_vs_ai_setup()
+
+
+def test_invalid_setups() -> None:
+    _test_invalid_setups()
+
+
+def test_turn_management() -> None:
+    _test_turn_management()

--- a/tests/test_model_paths.py
+++ b/tests/test_model_paths.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from poker_ai.utils.model_paths import find_latest_model_checkpoint
+
+
+def test_find_latest_model_checkpoint_empty(tmp_path: Path) -> None:
+    assert find_latest_model_checkpoint(directory=tmp_path) is None
+
+
+def test_find_latest_model_checkpoint_returns_latest(tmp_path: Path) -> None:
+    first = tmp_path / "first_model.pth"
+    second = tmp_path / "second_model.pth"
+    first.write_bytes(b"first")
+    time.sleep(0.01)
+    second.write_bytes(b"second")
+
+    latest = find_latest_model_checkpoint(directory=tmp_path)
+    assert latest is not None
+    path, _ = latest
+    assert path == str(second)
+
+
+def test_find_latest_model_checkpoint_prefix_fallback(tmp_path: Path) -> None:
+    base = tmp_path / "base_model.pth"
+    base.write_bytes(b"base")
+
+    prefixed = tmp_path / "custom_model.pth"
+    time.sleep(0.01)
+    prefixed.write_bytes(b"custom")
+
+    latest_prefixed = find_latest_model_checkpoint(directory=tmp_path, prefix="custom")
+    assert latest_prefixed is not None
+    path, _ = latest_prefixed
+    assert path == str(prefixed)
+
+    # Asking for a missing prefix should fall back to the newest checkpoint.
+    fallback = find_latest_model_checkpoint(directory=tmp_path, prefix="missing")
+    assert fallback is not None
+    fallback_path, _ = fallback
+    assert fallback_path == str(prefixed)


### PR DESCRIPTION
## Summary
- add a shared helper for locating the newest saved model checkpoint
- update the self-play loop to bootstrap and hot-reload from the freshest weights file
- let the human-vs-ai CLI automatically pick the latest model and log fallbacks
- cover the checkpoint discovery helper with unit tests
- wrap the legacy GUI human-vs-AI smoke checks in pytest modules so both expected test entrypoints succeed

## Testing
- pytest tests/test_model_paths.py tests/test_model_loader.py tests/test_gui_human_vs_ai.py tests/gui/test_gui_human_vs_ai.py


------
https://chatgpt.com/codex/tasks/task_b_68d00ac064d0832a8215fcc934c661f6