### PR TITLE
Ensure self-play reloads the latest model checkpoints

### DIFF
--- a/src/poker_ai/ai/trainers/ai_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/ai_cfr_trainer.py
@@ -342,21 +342,23 @@ class AICFRTrainer:
         except Exception as e:
             logging.error(f"Error saving model: {str(e)}", exc_info=True)
 
-    def load_model(self):
+    def load_model(self, model_path: str | None = None):
         # Ensure config path is correct or make it an argument
         try:
+            training_cfg = self.config.get("training", {}) if isinstance(self.config, dict) else {}
+            path = model_path or training_cfg.get("save_model_path") or config["training"]["save_model_path"]
+            if not path:
+                raise FileNotFoundError("No model path available to load weights.")
             map_location = self.device
             if self._using_xla:
                 map_location = "cpu"
-            payload = torch.load(
-                config["training"]["save_model_path"], map_location=map_location
-            )
+            payload = torch.load(path, map_location=map_location)
             state_dict = payload["state_dict"] if isinstance(payload, dict) and "state_dict" in payload else payload
             self.model.load_state_dict(state_dict)
             target_device = self._xla_device or self.device
             self.model.to(target_device)
             self.model.eval()
-            logging.info(f"Model loaded from {config['training']['save_model_path']}")
+            logging.info(f"Model loaded from {path}")
         except Exception as e:
             logging.error(f"Error loading model: {str(e)}", exc_info=True)
 

--- a/src/poker_ai/selfplay/distributed_self_play.py
+++ b/src/poker_ai/selfplay/distributed_self_play.py
@@ -31,7 +31,7 @@ def _run_multiple_hands(args: dict[str, Any]) -> list[list[Any]]:
         game_engine_config,
         training_config=training_config,
     )
-    return [sp.play_hand_for_training() for _ in range(num_hands)]
+    return [sp.play_hand_for_training(iteration=i + 1) for i in range(num_hands)]
 
 
 class DistributedSelfPlay:

--- a/src/poker_ai/selfplay/self_play.py
+++ b/src/poker_ai/selfplay/self_play.py
@@ -3,8 +3,10 @@
 # ruff: noqa
 
 import copy
+import logging
 import random
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, List, Optional
 
 import torch
@@ -48,12 +50,181 @@ class SelfPlay:
         self.min_players = game_engine_config.get("min_players", 2)
         self.max_players = game_engine_config.get("max_players", 10)
         cfg = training_config or {}
+        self.training_config = cfg
         min_buffer_raw = cfg.get("min_buffer_before_train", 256)
         try:
             min_buffer = int(min_buffer_raw)
         except (TypeError, ValueError):  # pragma: no cover - defensive
             min_buffer = 256
         self.min_buffer_before_train = max(1, min_buffer)
+        self._model_reload_interval = self._determine_model_reload_interval(cfg)
+        self._last_loaded_model_path: Path | None = None
+        self._last_loaded_model_mtime: float | None = None
+        self._maybe_refresh_model(iteration=0, force=True)
+
+    def _determine_model_reload_interval(self, cfg: dict[str, Any]) -> int:
+        """Return the frequency (in hands) for refreshing model weights."""
+
+        interval_raw = (
+            cfg.get("reload_model_every_hands")
+            or cfg.get("check_for_new_model_every_hands")
+            or cfg.get("save_model_every_n_hands")
+        )
+        try:
+            interval = int(interval_raw)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            interval = 1
+        if interval <= 0:
+            interval = 1
+        return interval
+
+    def _candidate_model_paths(self) -> list[Path]:
+        """Return possible checkpoint files to inspect for refreshes."""
+
+        candidates: list[Path] = []
+        direct_paths: list[str] = []
+        training_cfg = self.training_config if isinstance(self.training_config, dict) else {}
+        direct_paths.extend(
+            [
+                training_cfg.get("latest_model_path"),
+                training_cfg.get("save_model_path"),
+            ]
+        )
+
+        trainer_cfg = getattr(self.cfr_trainer, "config", {})
+        model_cfg: dict[str, Any] = {}
+        if isinstance(trainer_cfg, dict):
+            training_section = trainer_cfg.get("training")
+            if isinstance(training_section, dict):
+                direct_paths.append(training_section.get("save_model_path"))
+            maybe_model_cfg = trainer_cfg.get("model")
+            if isinstance(maybe_model_cfg, dict):
+                model_cfg = maybe_model_cfg
+
+        model_directory = training_cfg.get("model_directory") or model_cfg.get("directory")
+        filename_prefix = training_cfg.get("model_filename_prefix") or model_cfg.get(
+            "filename_prefix"
+        )
+
+        for path_str in direct_paths:
+            if not path_str:
+                continue
+            candidate = Path(path_str).expanduser()
+            if candidate.is_file():
+                candidates.append(candidate)
+
+        directories_to_search: list[Path] = []
+        if isinstance(model_directory, str) and model_directory:
+            directories_to_search.append(Path(model_directory).expanduser())
+        directories_to_search.append(Path("models"))
+
+        patterns: list[str] = ["*.pth"]
+        if isinstance(filename_prefix, str) and filename_prefix:
+            patterns.append(f"{filename_prefix}*.pth")
+
+        for directory in directories_to_search:
+            try:
+                if not directory.is_dir():
+                    continue
+            except OSError:  # pragma: no cover - defensive
+                continue
+            for pattern in patterns:
+                for path in directory.glob(pattern):
+                    if path.is_file():
+                        candidates.append(path)
+
+        unique: list[Path] = []
+        seen: set[str] = set()
+        for path in candidates:
+            try:
+                resolved = str(path.resolve())
+            except OSError:  # pragma: no cover - defensive
+                resolved = str(path)
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            unique.append(path)
+        return unique
+
+    def _find_latest_model_checkpoint(self) -> Path | None:
+        """Return the most recently modified checkpoint file if available."""
+
+        candidates = self._candidate_model_paths()
+        if not candidates:
+            return None
+
+        latest_path = None
+        latest_mtime = float("-inf")
+        for path in candidates:
+            try:
+                mtime = path.stat().st_mtime
+            except OSError:
+                continue
+            if mtime > latest_mtime:
+                latest_mtime = mtime
+                latest_path = path
+        return latest_path
+
+    def _load_model_from_path(self, path: Path) -> bool:
+        """Invoke the trainer's load routine for ``path`` if possible."""
+
+        load_attr = getattr(self.cfr_trainer, "load_model", None)
+        if load_attr is None:
+            return False
+
+        try:
+            load_attr(str(path))
+        except TypeError:
+            load_attr()
+        except FileNotFoundError:
+            logging.warning("Checkpoint %s disappeared before it could be loaded.", path)
+            return False
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logging.error("Failed to load model from %s: %s", path, exc)
+            return False
+        return True
+
+    def _maybe_refresh_model(self, iteration: int, *, force: bool = False) -> None:
+        """Reload the latest checkpoint when due or when forced."""
+
+        if not force:
+            if self._model_reload_interval <= 0:
+                return
+            if iteration <= 0:
+                return
+            if iteration % self._model_reload_interval != 0:
+                return
+
+        latest_path = self._find_latest_model_checkpoint()
+        if latest_path is None:
+            return
+
+        try:
+            latest_mtime = latest_path.stat().st_mtime
+        except OSError:
+            return
+
+        if (
+            not force
+            and self._last_loaded_model_path is not None
+            and self._last_loaded_model_mtime is not None
+        ):
+            try:
+                same_path = latest_path.resolve() == self._last_loaded_model_path
+            except OSError:  # pragma: no cover - defensive
+                same_path = False
+            if same_path and latest_mtime <= self._last_loaded_model_mtime:
+                return
+
+        if not self._load_model_from_path(latest_path):
+            return
+
+        try:
+            resolved = latest_path.resolve()
+        except OSError:  # pragma: no cover - defensive
+            resolved = latest_path
+        self._last_loaded_model_path = resolved
+        self._last_loaded_model_mtime = latest_mtime
  
 
     def _normalization_scale_for_game(self, game: TexasHoldem) -> float:
@@ -76,6 +247,7 @@ class SelfPlay:
 
     def play_hand_for_training(self, iteration: int = 0) -> list[Any]:
         """Run one full MCCFR traversal for a new hand."""
+        self._maybe_refresh_model(iteration)
         # 1. Initialize a new hand with a random number of players
         num_players = random.randint(self.min_players, self.max_players)
         game = TexasHoldem(num_players=num_players, starting_stack=self.starting_stack)

--- a/tests/test_self_play.py
+++ b/tests/test_self_play.py
@@ -1,6 +1,6 @@
 import os
 import sys
-
+import time
 from types import MethodType, SimpleNamespace
 
 import pytest
@@ -35,12 +35,16 @@ class DummyTrainer:
         self.config = {"model": {"max_seq_len": 10, "d_raw_feature": 2}}
         self.num_actions = 2
         self.replay_buffer = self.Buffer()
+        self.loaded_paths: list[str | None] = []
 
     def get_advantages(self, hole, community, history):
         return torch.zeros(self.num_actions)
 
     def train(self, state_tensor=None, cf_payoffs=None, batch_size=None):
         return None
+
+    def load_model(self, path: str | None = None):
+        self.loaded_paths.append(path)
 
 
 def test_play_hand_for_training_runs():
@@ -91,6 +95,59 @@ def test_play_hand_for_training_respects_custom_buffer_threshold():
         sp.play_hand_for_training(iteration=123)
 
     trainer.train.assert_called_once_with(batch_size=2)
+
+
+def test_self_play_reloads_latest_checkpoint_when_updated(tmp_path):
+    trainer = DummyTrainer()
+    trainer.train = MagicMock(return_value=None)
+    model_path = tmp_path / "model.pth"
+    model_path.write_bytes(b"initial")
+
+    training_cfg = {
+        "save_model_path": str(model_path),
+        "reload_model_every_hands": 1,
+        "min_buffer_before_train": 1,
+    }
+
+    class DummyGame:
+        def __init__(self, num_players: int, starting_stack: int) -> None:
+            self.rules = SimpleNamespace(
+                big_blind=0,
+                small_blind=0,
+                num_players=num_players,
+                dealer_button=0,
+                active_players=[True] * num_players,
+                player_chips=[starting_stack] * num_players,
+                community_cards=[],
+                current_player=0,
+            )
+
+        def initialize_game(self) -> None:
+            return None
+
+        def clone(self) -> "DummyGame":
+            return self
+
+    with (
+        patch("poker_ai.selfplay.self_play.random.randint", return_value=2),
+        patch("poker_ai.selfplay.self_play.TexasHoldem", DummyGame),
+        patch.object(SelfPlay, "_traverse_mccfr", return_value=0),
+    ):
+        sp = SelfPlay(
+            trainer,
+            {"num_players": 2, "starting_stack": 50},
+            training_config=training_cfg,
+        )
+
+        assert trainer.loaded_paths[-1] == str(model_path)
+        trainer.loaded_paths.clear()
+
+        time.sleep(0.01)
+        model_path.write_bytes(b"updated")
+
+        sp.play_hand_for_training(iteration=1)
+
+    assert trainer.loaded_paths[-1] == str(model_path)
 
 
 def test_extract_game_data_uses_betting_history_directly():

--- a/training/train.py
+++ b/training/train.py
@@ -1,6 +1,8 @@
 """Command-line entry for basic training loop using self-play."""
 
 import argparse
+import os
+from typing import Any
 
 from poker_ai.selfplay.self_play import SelfPlay
 from poker_ai.ai.trainers.ai_cfr_trainer import AICFRTrainer
@@ -31,10 +33,28 @@ def main() -> None:
     }
 
     trainer = AICFRTrainer()
-    self_play_env = SelfPlay(cfr_trainer=trainer, game_engine_config=game_cfg)
+
+    training_cfg: dict[str, Any] = {}
+    trainer_cfg = getattr(trainer, "config", {})
+    if isinstance(trainer_cfg, dict):
+        training_section = trainer_cfg.get("training")
+        if isinstance(training_section, dict):
+            save_path = training_section.get("save_model_path")
+            if isinstance(save_path, str) and save_path:
+                training_cfg["save_model_path"] = save_path
+                if os.path.isfile(save_path):
+                    trainer.load_model(save_path)
+    if args.save_interval:
+        training_cfg["save_model_every_n_hands"] = args.save_interval
+
+    self_play_env = SelfPlay(
+        cfr_trainer=trainer,
+        game_engine_config=game_cfg,
+        training_config=training_cfg or None,
+    )
 
     for hand_idx in range(1, args.num_hands + 1):
-        self_play_env.play_hand_for_training()
+        self_play_env.play_hand_for_training(hand_idx)
         if args.save_interval and hand_idx % args.save_interval == 0:
             trainer.save_model()
     trainer.save_model()


### PR DESCRIPTION
## Summary
- teach `SelfPlay` to locate the newest checkpoint, load it at startup, and refresh it on a configurable cadence
- allow the basic training script and distributed helpers to pass iteration counts and reuse the latest saved weights
- update AICFRTrainer to accept an optional path when loading and extend self-play tests to cover checkpoint refresh behavior

## Testing
- `pytest tests/test_self_play.py -q`
- `pytest tests/test_run_training.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68d0c679db28832ab2a0f1ae941c87f2