### PR TITLE
Guard betting round cleanup call

### DIFF
--- a/src/poker_ai/selfplay/self_play.py
+++ b/src/poker_ai/selfplay/self_play.py
@@ -363,7 +363,9 @@ class SelfPlay:
     def _advance_street(self, game: TexasHoldem) -> None:
         """Advance the existing game to the next street without allocating a clone."""
 
-        game.rules.end_betting_round_cleanup()
+        cleanup = getattr(game.rules, "end_betting_round_cleanup", None)
+        if callable(cleanup):
+            cleanup()
 
         community_cards = game.rules.community_cards
         if len(community_cards) == 0:


### PR DESCRIPTION
## Summary
- avoid calling `end_betting_round_cleanup` when the rules object does not provide it before advancing the street during MCCFR traversal

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d6181a77e8832a8433f6024712eed5