### PR TITLE
Randomize bankroll when omitted

### DIFF
--- a/gatc_holdem/engine/__init__.py
+++ b/gatc_holdem/engine/__init__.py
@@ -1,3 +1,4 @@
+from .cash_table import CashPlayer, CashTable, LegalActions, PotLayer, RaiseBounds
 from .rules import (
     build_side_pots,
     min_bet,
@@ -7,6 +8,11 @@ from .rules import (
 )
 
 __all__ = [
+    "CashPlayer",
+    "CashTable",
+    "LegalActions",
+    "PotLayer",
+    "RaiseBounds",
     "min_bet",
     "min_raise_to",
     "raise_reopens_action",

--- a/gatc_holdem/engine/cash_table.py
+++ b/gatc_holdem/engine/cash_table.py
@@ -1,0 +1,309 @@
+"""Cash-game table state management with table-stakes constraints."""
+
+from __future__ import annotations
+
+import random
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+from .rules import min_raise_to, split_winnings_with_odd_chips
+
+_EPSILON = 1e-9
+
+
+@dataclass
+class CashPlayer:
+    """State for a player seated in a cash game."""
+
+    pid: int
+    stack: float
+    bankroll: float
+    seated: bool = True
+    in_hand: bool = False
+    committed: float = 0.0
+    folded: bool = False
+    all_in: bool = False
+
+    def available_to_bet(self) -> float:
+        if not self.in_hand or self.folded:
+            return 0.0
+        return max(0.0, self.stack)
+
+    def commit(self, amount: float) -> float:
+        """Move chips from stack to the pot, enforcing table-stakes."""
+
+        if amount <= 0 or not self.in_hand or self.folded:
+            return 0.0
+        move = min(amount, self.stack)
+        if move <= 0:
+            return 0.0
+        self.stack -= move
+        if self.stack <= _EPSILON:
+            self.stack = 0.0
+            self.all_in = True
+        self.committed += move
+        return move
+
+    def reset_for_new_hand(self, *, active: bool) -> None:
+        self.in_hand = active and self.seated and self.stack > _EPSILON
+        self.committed = 0.0
+        self.folded = False
+        self.all_in = False
+
+
+@dataclass
+class PotLayer:
+    """Represents a main or side pot capped at a contribution level."""
+
+    cap_per_player: float
+    contributors: List[int] = field(default_factory=list)
+    eligible: List[int] = field(default_factory=list)
+    amount: float = 0.0
+
+
+@dataclass
+class RaiseBounds:
+    """Information about available raise sizes for an acting player."""
+
+    min_total: float
+    max_total: float
+    min_reopens: bool
+    max_reopens: bool
+
+
+@dataclass
+class LegalActions:
+    """Summary of the legal options for a player on their turn."""
+
+    can_fold: bool
+    can_check: bool
+    call_amount: Optional[float]
+    raise_bounds: Optional[RaiseBounds]
+
+
+@dataclass
+class CashTable:
+    """Implements casino-style table-stakes cash game rules."""
+
+    small_blind: float
+    big_blind: float
+    min_buyin_bb: int = 40
+    max_buyin_bb: int = 100
+    min_bankroll_buyins: int = 1
+    max_bankroll_buyins: int = 5
+    rake_pct: float = 0.0
+    rake_cap: float = 0.0
+    no_flop_no_drop: bool = True
+    players: Dict[int, CashPlayer] = field(default_factory=dict)
+    button_idx: int = 0
+    pot_layers: List[PotLayer] = field(default_factory=list)
+    board_reached_flop: bool = False
+    hand_start_stacks: Dict[int, float] = field(default_factory=dict)
+
+    def seat_player(
+        self,
+        pid: int,
+        bankroll: Optional[float] = None,
+        buyin_bb: Optional[int] = None,
+    ) -> None:
+        if self.min_buyin_bb > self.max_buyin_bb:
+            raise ValueError("min_buyin_bb cannot exceed max_buyin_bb")
+        if self.min_bankroll_buyins > self.max_bankroll_buyins:
+            raise ValueError("min_bankroll_buyins cannot exceed max_bankroll_buyins")
+
+        if buyin_bb is None:
+            buyin_bb = random.randint(self.min_buyin_bb, self.max_buyin_bb)
+        if buyin_bb < self.min_buyin_bb or buyin_bb > self.max_buyin_bb:
+            raise ValueError("buy-in outside allowed range")
+
+        if bankroll is None:
+            bankroll_buyins = random.randint(self.min_bankroll_buyins, self.max_bankroll_buyins)
+            bankroll = bankroll_buyins * buyin_bb * self.big_blind
+        if bankroll < 0:
+            raise ValueError("bankroll must be non-negative")
+
+        buyin_amount = min(bankroll, buyin_bb * self.big_blind)
+        buyin_amount = max(0.0, buyin_amount)
+        remaining = bankroll - buyin_amount
+        if remaining < 0 and abs(remaining) <= _EPSILON:
+            remaining = 0.0
+        self.players[pid] = CashPlayer(
+            pid=pid,
+            stack=buyin_amount,
+            bankroll=remaining,
+        )
+
+    def start_hand(self, active_pids: Iterable[int]) -> None:
+        active = set(active_pids)
+        for player in self.players.values():
+            player.reset_for_new_hand(active=player.pid in active)
+        self.pot_layers.clear()
+        self.board_reached_flop = False
+        self.hand_start_stacks = {
+            pid: player.stack for pid, player in self.players.items() if player.in_hand
+        }
+
+    def stack_at_hand_start(self, pid: int) -> float:
+        """Return the stack a player brought into the current hand."""
+
+        return self.hand_start_stacks.get(pid, 0.0)
+
+    def mark_flop_seen(self) -> None:
+        self.board_reached_flop = True
+
+    def post_blind(self, pid: int, amount: float) -> float:
+        player = self.players.get(pid)
+        if player is None:
+            raise KeyError(pid)
+        return player.commit(amount)
+
+    def mark_fold(self, pid: int) -> None:
+        player = self.players.get(pid)
+        if player is None:
+            raise KeyError(pid)
+        if player.in_hand:
+            player.folded = True
+
+    def legal_actions(self, pid: int, to_call: float, last_raise: float) -> LegalActions:
+        player = self.players.get(pid)
+        if player is None:
+            raise KeyError(pid)
+        if not player.in_hand or player.folded:
+            return LegalActions(can_fold=False, can_check=False, call_amount=None, raise_bounds=None)
+
+        max_bet = player.available_to_bet()
+        outstanding = max(0.0, to_call - player.committed)
+        call_amount = min(outstanding, max_bet)
+        can_check = outstanding <= _EPSILON
+        raise_bounds: Optional[RaiseBounds] = None
+
+        if max_bet - call_amount > _EPSILON:
+            max_total = player.committed + max_bet
+            try:
+                min_raise_total = float(min_raise_to(int(round(to_call)), int(round(last_raise)), int(round(self.big_blind))))
+            except ValueError:
+                min_raise_total = to_call + max(last_raise, 0.0)
+            min_raise_total = max(min_raise_total, player.committed + call_amount)
+            min_raise_total = min(min_raise_total, max_total)
+            if min_raise_total <= max_total + _EPSILON:
+                min_reopens = (min_raise_total - to_call) >= max(last_raise, 0.0) - _EPSILON
+                max_reopens = (max_total - to_call) >= max(last_raise, 0.0) - _EPSILON
+                raise_bounds = RaiseBounds(
+                    min_total=min_raise_total,
+                    max_total=max_total,
+                    min_reopens=min_reopens,
+                    max_reopens=max_reopens,
+                )
+
+        call_value: Optional[float] = None
+        if not can_check:
+            call_value = call_amount
+
+        return LegalActions(
+            can_fold=True,
+            can_check=can_check,
+            call_amount=call_value,
+            raise_bounds=raise_bounds,
+        )
+
+    def bet_or_raise_to(self, pid: int, target_total: float) -> float:
+        player = self.players.get(pid)
+        if player is None:
+            raise KeyError(pid)
+        if target_total < player.committed - _EPSILON:
+            raise ValueError("target total must be >= current commitment")
+        additional = target_total - player.committed
+        return player.commit(additional)
+
+    def _all_contributions(self) -> Dict[int, float]:
+        contrib: Dict[int, float] = {}
+        for pid, player in self.players.items():
+            if player.in_hand and player.committed > _EPSILON:
+                contrib[pid] = player.committed
+        return contrib
+
+    def build_side_pots(self) -> None:
+        contributions = self._all_contributions()
+        if not contributions:
+            self.pot_layers.clear()
+            return
+
+        unique_levels = sorted({amount for amount in contributions.values() if amount > _EPSILON})
+        if not unique_levels:
+            self.pot_layers.clear()
+            return
+
+        self.pot_layers = []
+        prev = 0.0
+        for level in unique_levels:
+            width = level - prev
+            if width <= _EPSILON:
+                prev = level
+                continue
+            contributors = [pid for pid, amt in contributions.items() if amt >= level - _EPSILON]
+            eligible = [pid for pid in contributors if self.players[pid].in_hand and not self.players[pid].folded]
+            if not contributors:
+                prev = level
+                continue
+            amount = width * len(contributors)
+            self.pot_layers.append(
+                PotLayer(
+                    cap_per_player=level,
+                    contributors=contributors,
+                    eligible=eligible,
+                    amount=amount,
+                )
+            )
+            prev = level
+
+    def take_rake(self) -> float:
+        total = sum(layer.amount for layer in self.pot_layers)
+        if total <= _EPSILON:
+            return 0.0
+        if self.no_flop_no_drop and not self.board_reached_flop:
+            return 0.0
+
+        desired = total * self.rake_pct
+        rake = min(desired, self.rake_cap)
+        rake = round(rake, 2)
+        if rake <= _EPSILON:
+            return 0.0
+
+        remaining = rake
+        for layer in self.pot_layers:
+            if remaining <= 0:
+                break
+            deduct = min(layer.amount, remaining)
+            layer.amount -= deduct
+            remaining -= deduct
+        return rake - remaining
+
+    def pay_out(self, winners_per_layer: Dict[int, Iterable[int]]) -> None:
+        for idx, layer in enumerate(self.pot_layers):
+            winners = list(winners_per_layer.get(idx, []))
+            eligible = {pid for pid in layer.eligible}
+            valid_winners = [pid for pid in winners if pid in eligible]
+            if not valid_winners:
+                continue
+            split = split_winnings_with_odd_chips(int(round(layer.amount)), valid_winners, self.button_idx)
+            for pid, amount in split.items():
+                self.players[pid].stack += amount
+
+    def top_up(self, pid: int, target_bb: int) -> float:
+        player = self.players.get(pid)
+        if player is None:
+            raise KeyError(pid)
+        target_amount = target_bb * self.big_blind
+        missing = max(0.0, target_amount - player.stack)
+        add = min(missing, player.bankroll)
+        if add <= _EPSILON:
+            return 0.0
+        player.stack += add
+        player.bankroll -= add
+        return add
+
+    @property
+    def total_pot(self) -> float:
+        return sum(layer.amount for layer in self.pot_layers)
+

--- a/tests/engine/test_cash_table.py
+++ b/tests/engine/test_cash_table.py
@@ -1,0 +1,143 @@
+import os
+import random
+import sys
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+for path in (PROJECT_ROOT, SRC_PATH):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+from gatc_holdem.engine import CashTable  # noqa: E402
+
+
+def _setup_table():
+    table = CashTable(small_blind=1, big_blind=2, rake_pct=0.05, rake_cap=5)
+    table.seat_player(pid=0, bankroll=500, buyin_bb=100)
+    table.seat_player(pid=1, bankroll=300, buyin_bb=50)
+    table.seat_player(pid=2, bankroll=300, buyin_bb=40)
+    table.start_hand([0, 1, 2])
+    return table
+
+
+def test_start_hand_records_initial_stacks():
+    table = _setup_table()
+    # Active players should have their starting stack captured
+    assert table.stack_at_hand_start(0) == table.players[0].stack
+    assert table.stack_at_hand_start(1) == table.players[1].stack
+    assert table.stack_at_hand_start(2) == table.players[2].stack
+
+    # Remove player 2 for the next hand and ensure snapshot updates
+    table.players[2].stack = 0
+    table.start_hand([0, 1])
+    assert table.stack_at_hand_start(0) == table.players[0].stack
+    assert table.stack_at_hand_start(1) == table.players[1].stack
+    assert table.stack_at_hand_start(2) == 0
+
+
+def test_short_blind_all_in_sets_all_in_flag():
+    table = _setup_table()
+    # Exhaust player 2 stack to simulate short blind
+    table.players[2].stack = 1
+    posted = table.post_blind(2, table.big_blind)
+    assert posted == 1
+    assert table.players[2].stack == 0
+    assert table.players[2].all_in is True
+
+
+def test_legal_actions_min_raise_bounds():
+    table = _setup_table()
+    actor = table.players[0]
+    actor.committed = 0
+    table.players[1].commit(2)  # big blind amount already in
+    # Player 0 faces a raise to 6 with last full raise size of 4
+    actions = table.legal_actions(pid=0, to_call=6, last_raise=4)
+    assert actions.call_amount == 6
+    assert actions.raise_bounds is not None
+    assert actions.raise_bounds.min_total == 10
+    assert actions.raise_bounds.max_total == actor.stack
+
+
+def test_short_stack_cannot_reopen_action():
+    table = _setup_table()
+    player = table.players[1]
+    player.stack = 3
+    player.committed = 0
+    actions = table.legal_actions(pid=1, to_call=2, last_raise=2)
+    assert actions.call_amount == 2
+    assert actions.raise_bounds is not None
+    assert actions.raise_bounds.min_total == actions.raise_bounds.max_total == 3
+    assert actions.raise_bounds.min_reopens is False
+
+
+def test_build_side_pots_with_folded_players():
+    table = _setup_table()
+    table.players[0].commit(50)
+    table.players[1].commit(100)
+    table.players[2].stack = 200
+    table.players[2].commit(100)
+    table.players[2].folded = True
+    table.build_side_pots()
+    assert len(table.pot_layers) == 2
+    main_pot, side_pot = table.pot_layers
+    assert main_pot.amount == 150
+    assert set(main_pot.eligible) == {0, 1}
+    assert side_pot.amount == 100
+    assert set(side_pot.eligible) == {1}
+
+
+def test_take_rake_no_flop_no_drop():
+    table = _setup_table()
+    table.players[0].commit(50)
+    table.players[1].commit(50)
+    table.build_side_pots()
+    rake = table.take_rake()
+    assert rake == 0
+    table.mark_flop_seen()
+    rake = table.take_rake()
+    assert rake == 5  # 5% of 100 capped at 5
+    assert abs(table.total_pot - 95) < 1e-9
+
+
+def test_pay_out_uses_odd_chip_rule():
+    table = _setup_table()
+    table.button_idx = 0
+    table.players[0].commit(50)
+    table.players[1].commit(50)
+    table.build_side_pots()
+    table.pot_layers[0].amount = 101
+    table.pay_out({0: [0, 1]})
+    assert table.players[0].stack == table.big_blind * 100
+    assert table.players[1].stack == table.big_blind * 50 + 1
+
+
+def test_top_up_respects_bankroll():
+    table = _setup_table()
+    table.players[1].stack = 50
+    table.players[1].bankroll = 40
+    added = table.top_up(1, target_bb=60)
+    assert added == 40
+    assert table.players[1].stack == 90
+    assert table.players[1].bankroll == 0
+
+
+def test_seat_player_random_defaults_within_range():
+    table = CashTable(
+        small_blind=1,
+        big_blind=2,
+        min_buyin_bb=40,
+        max_buyin_bb=100,
+        min_bankroll_buyins=2,
+        max_bankroll_buyins=4,
+    )
+    random.seed(0)
+    table.seat_player(pid=7)
+    player = table.players[7]
+    assert table.min_buyin_bb <= player.stack / table.big_blind <= table.max_buyin_bb
+    total_funds = player.stack + player.bankroll
+    bankroll_buyins = total_funds / player.stack
+    assert table.min_bankroll_buyins <= bankroll_buyins <= table.max_bankroll_buyins
+    assert bankroll_buyins == 3
+    assert player.stack == 94 * table.big_blind
+    assert player.bankroll == player.stack * (bankroll_buyins - 1)
+


### PR DESCRIPTION
## Summary
- allow `CashTable.seat_player` to optionally sample both buy-in and bankroll sizes using configurable ranges
- validate bankroll/buy-in range settings and ensure remaining bankroll bookkeeping stays non-negative
- update the cash table regression test to cover default bankroll sampling

## Testing
- pytest tests/engine/test_cash_table.py -q

------
https://chatgpt.com/codex/tasks/task_b_68d53bc3e334832a883884edbbaa7513