### PR TITLE
Expand automated test coverage for accelerators and assets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,10 @@ that saved checkpoints can still be ranked without XLA kernels.
    pytest -q
    ```
    Extensive unit tests exercise action validation, deck shuffling/dealing,
-   game-state transitions, hand evaluation error paths, and CLI defaults.
+   game-state transitions, hand evaluation error paths, and CLI defaults.  The
+   suite also verifies that all bundled card images and the poker table
+   background are present so missing art assets are caught automatically (see
+   `tests/gui/test_card_assets.py`).
 
 4. **Play against the AI**:
    ```bash

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -1,162 +1,212 @@
 #!/usr/bin/env python3
-"""
-Comprehensive test runner for Texas Hold'em AI project.
-Tests all core components and provides a summary.
+"""Texas Hold'em AI test orchestrator.
+
+This helper wraps ``pytest`` so contributors can run the complete automated
+suite with a single command.  By default the entire ``tests/`` tree (including
+unit, integration, CLI, and service tests) is executed.  Optional flags enable
+additional slow checks such as the GUI smoke tests, end-to-end scenarios, and
+performance harnesses.
+
+Examples
+--------
+Run the default fast suite::
+
+    ./run_all_tests.py
+
+Include the slower end-to-end and GUI checks::
+
+    ./run_all_tests.py --include-e2e --include-gui
+
+Run every target the script knows about::
+
+    ./run_all_tests.py --include-all
 """
 
-import os
+from __future__ import annotations
+
+import argparse
 import shlex
 import subprocess
 import sys
-import traceback
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
 
-# Add project root and source directory to path
-project_root = os.path.abspath(os.path.dirname(__file__))
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)
+@dataclass
+class TestTarget:
+    """Definition of an individual test command."""
 
-# Ensure the src directory is available for imports
-src_path = os.path.join(project_root, "src")
-if src_path not in sys.path:
-    sys.path.insert(0, src_path)
+    name: str
+    command: Sequence[str]
 
 
-def run_test_suite(test_name, test_command):
-    """Run a test suite and return result."""
+@dataclass
+class TestResult:
+    """Outcome of executing a :class:`TestTarget`."""
+
+    target: TestTarget
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def succeeded(self) -> bool:
+        return self.returncode == 0
+
+
+def _run_target(target: TestTarget) -> TestResult:
+    """Execute ``target`` and capture its output."""
+
+    print(f"\n=== Running {target.name} ===")
+    print("$", " ".join(shlex.quote(part) for part in target.command))
     try:
-        print(f"\n--- Testing {test_name} ---")
-        command_list = shlex.split(test_command)
-        result = subprocess.run(
-            command_list, capture_output=True, text=True, timeout=30
+        completed = subprocess.run(
+            list(target.command),
+            check=False,
+            text=True,
+            capture_output=True,
         )
+    except FileNotFoundError as exc:
+        message = f"Failed to launch {target.name}: {exc}"
+        print(message)
+        return TestResult(target=target, returncode=127, stdout="", stderr=message)
 
-        if result.returncode == 0:
-            print(f"✅ {test_name}: PASSED")
-            return True
-        else:
-            print(f"❌ {test_name}: FAILED")
-            if result.stdout:
-                print(f"STDOUT: {result.stdout}")
-            if result.stderr:
-                print(f"STDERR: {result.stderr}")
-            return False
+    if completed.stdout:
+        print(completed.stdout.rstrip())
+    if completed.stderr:
+        print(completed.stderr.rstrip())
 
-    except subprocess.TimeoutExpired:
-        print(f"⏰ {test_name}: TIMEOUT (>30s)")
-        return False
-    except Exception as e:
-        print(f"💥 {test_name}: ERROR - {e}")
-        return False
+    if completed.returncode == 0:
+        print(f"✔ {target.name} completed successfully.")
+    else:
+        print(f"✖ {target.name} failed with exit code {completed.returncode}.")
 
-
-def test_imports():
-    """Test that all critical imports work."""
-    try:
-        print("\n--- Testing Critical Imports ---")
-
-        # Test game engine
-
-        print("✅ Game engine imports")
-
-        # Test strategies
-
-        print("✅ Strategy imports")
-
-        # Test AI components
-
-        print("✅ AI model imports")
-
-        # Test GUI (mock tkinter to avoid display issues)
-        import sys
-        from unittest.mock import MagicMock
-
-        sys.modules["tkinter"] = MagicMock()
-        sys.modules["tkinter.messagebox"] = MagicMock()
-        sys.modules["tkinter.simpledialog"] = MagicMock()
-
-        print("✅ GUI imports")
-
-        return True
-
-    except Exception as e:
-        print(f"❌ Import error: {e}")
-        traceback.print_exc()
-        return False
+    return TestResult(
+        target=target,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
 
 
-def test_basic_game_logic():
-    """Test basic game functionality."""
-    try:
-        print("\n--- Testing Basic Game Logic ---")
+def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--include-e2e",
+        action="store_true",
+        help="Also run end-to-end tests located under tests/e2e.",
+    )
+    parser.add_argument(
+        "--include-gui",
+        action="store_true",
+        help="Run GUI smoke tests that rely on headless Tkinter rendering.",
+    )
+    parser.add_argument(
+        "--include-perf",
+        action="store_true",
+        help="Run performance regression smoke tests under tests/perf.",
+    )
+    parser.add_argument(
+        "--include-all",
+        action="store_true",
+        help="Shortcut to enable all optional suites (e2e, gui, perf).",
+    )
+    parser.add_argument(
+        "--pytest-args",
+        default="",
+        help="Additional arguments appended to each pytest invocation.",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
 
-        from game_engine.texas_holdem import TexasHoldem
 
-        from playStrategy import RandomAIStrategy
-
-        # Create a simple game
-        strategies = [RandomAIStrategy(), RandomAIStrategy()]
-        game = TexasHoldem(2, 1000, strategies)
-
-        # Verify basic properties
-        assert game.num_players == 2
-        assert all(chips == 1000 for chips in game.rules.player_chips)
-        print("✅ Game creation and initialization")
-
-        # Test a simple hand (without full simulation to avoid complexity)
-        initial_deck_size = len(game.rules.deck.cards)
-        assert initial_deck_size == 52
-        print("✅ Deck initialization")
-
-        return True
-
-    except Exception as e:
-        print(f"❌ Game logic error: {e}")
-        traceback.print_exc()
-        return False
-
-
-def main():
-    """Run all tests and provide summary."""
-    print("🃏 Texas Hold'em AI - Comprehensive Test Suite")
-    print("=" * 50)
-
-    passed = 0
-    total = 0
-
-    # Test categories
-    test_cases = [
-        ("Critical Imports", test_imports),
-        ("Basic Game Logic", test_basic_game_logic),
-        ("Action Mapping", "python -m pytest tests/test_action_mapping.py -q"),
-        ("Texas Hold'em Rules", "python -m pytest tests/test_texas_holdem_rules.py -q"),
-        ("Betting Tree", "python -m pytest tests/test_betting_tree.py -q"),
-        ("Exploitability", "python -m pytest tests/test_exploitability.py -q"),
+def _build_matrix(args: argparse.Namespace) -> List[TestTarget]:
+    pytest_args = shlex.split(args.pytest_args)
+    matrix: List[TestTarget] = [
+        TestTarget(
+            name="pytest (core suite)",
+            command=[sys.executable, "-m", "pytest", "-q", *pytest_args],
+        )
     ]
 
-    for test_name, test_func_or_cmd in test_cases:
-        total += 1
+    include_e2e = args.include_all or args.include_e2e
+    include_gui = args.include_all or args.include_gui
+    include_perf = args.include_all or args.include_perf
 
-        if callable(test_func_or_cmd):
-            # Run Python function test
-            if test_func_or_cmd():
-                passed += 1
-        else:
-            # Run command line test
-            if run_test_suite(test_name, test_func_or_cmd):
-                passed += 1
+    if include_e2e:
+        matrix.append(
+            TestTarget(
+                name="pytest (end-to-end)",
+                command=[
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "tests/e2e",
+                    "-q",
+                    *pytest_args,
+                ],
+            )
+        )
 
-    # Summary
-    print("\n" + "=" * 50)
-    print(f"📊 TEST SUMMARY: {passed}/{total} tests passed")
+    if include_perf:
+        matrix.append(
+            TestTarget(
+                name="pytest (performance)",
+                command=[
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "tests/perf",
+                    "-q",
+                    *pytest_args,
+                ],
+            )
+        )
 
-    if passed == total:
-        print("🎉 All tests passed! The project is in good shape.")
-        return 0
-    else:
-        print(f"⚠️  {total - passed} tests failed. Check the output above for details.")
-        return 1
+    if include_gui:
+        gui_targets = [
+            "test_complete_gui.py",
+            "test_comprehensive_gui.py",
+            "test_gui_core.py",
+            "test_gui_faithfulness.py",
+            "test_gui_human_vs_ai.py",
+            "test_gui_integration.py",
+            "test_gui.py",
+            "test_card_images_gui.py",
+        ]
+        matrix.append(
+            TestTarget(
+                name="pytest (gui smoke)",
+                command=[
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "-q",
+                    *gui_targets,
+                    *pytest_args,
+                ],
+            )
+        )
+
+    return matrix
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _parse_args(argv)
+    matrix = _build_matrix(args)
+
+    results = [_run_target(target) for target in matrix]
+
+    print("\n=== Summary ===")
+    passed = 0
+    for result in results:
+        status = "PASS" if result.succeeded else "FAIL"
+        print(f"{status:>4}  {result.target.name}")
+        if result.succeeded:
+            passed += 1
+
+    total = len(results)
+    print(f"\nCompleted {total} command(s); {passed} succeeded, {total - passed} failed.")
+    return 0 if passed == total else 1
 
 
 if __name__ == "__main__":
-    exit_code = main()
-    sys.exit(exit_code)
+    raise SystemExit(main())

--- a/tests/cli/test_gcp_train.py
+++ b/tests/cli/test_gcp_train.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from poker_ai.cli import gcp_train
+
+
+def test_ensure_gcloud_available(monkeypatch):
+    monkeypatch.setattr(gcp_train.shutil, "which", lambda _: None)
+    with pytest.raises(SystemExit) as excinfo:
+        gcp_train.ensure_gcloud_available()
+    assert "gcloud" in str(excinfo.value)
+
+
+def test_ensure_gcloud_present(monkeypatch):
+    monkeypatch.setattr(gcp_train.shutil, "which", lambda _: "/usr/bin/gcloud")
+    gcp_train.ensure_gcloud_available()  # Should not raise
+
+
+def test_run_command_failure(monkeypatch):
+    def fake_run(cmd, check):
+        raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+
+    import subprocess
+
+    monkeypatch.setattr(gcp_train.subprocess, "run", fake_run)
+    with pytest.raises(SystemExit) as excinfo:
+        gcp_train._run_command(["gcloud", "version"])
+    assert "exit code 1" in str(excinfo.value)
+
+
+def test_create_instance_gpu(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(gcp_train, "ensure_gcloud_available", lambda: None)
+    monkeypatch.setattr(gcp_train, "_run_command", lambda cmd: recorded.append(cmd))
+
+    args = SimpleNamespace(
+        accelerator="gpu",
+        gpu_type="nvidia-a100-80gb",
+        gpu_count=2,
+        image=None,
+        image_family="pytorch-latest-gpu",
+        image_project="deeplearning-platform-release",
+        name="trainer",
+        project="proj",
+        zone="us-central1-a",
+        machine_type="n1-standard-8",
+        tpu_type=None,
+        tpu_version="tpu-vm-base",
+    )
+
+    gcp_train.create_instance(args)
+
+    assert recorded[0][:7] == [
+        "gcloud",
+        "compute",
+        "instances",
+        "create",
+        "trainer",
+        "--project",
+        "proj",
+    ]
+    assert "--accelerator" in recorded[0]
+    assert "type=nvidia-a100-80gb,count=2" in recorded[0]
+
+
+def test_create_instance_tpu(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(gcp_train, "ensure_gcloud_available", lambda: None)
+    monkeypatch.setattr(gcp_train, "_run_command", lambda cmd: recorded.append(cmd))
+
+    args = SimpleNamespace(
+        accelerator="tpu",
+        gpu_type=None,
+        gpu_count=0,
+        image=None,
+        image_family=None,
+        image_project=None,
+        name="trainer",
+        project="proj",
+        zone="us-central1-b",
+        machine_type="n1-standard-8",
+        tpu_type="v4-8",
+        tpu_version="tpu-vm-base",
+    )
+
+    gcp_train.create_instance(args)
+
+    assert recorded[0][:5] == ["gcloud", "alpha", "compute", "tpus", "tpu-vm"]
+    assert "--accelerator-type" in recorded[0]
+    assert "v4-8" in recorded[0]
+
+
+def test_run_training_gpu(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(gcp_train, "ensure_gcloud_available", lambda: None)
+    monkeypatch.setattr(gcp_train, "_run_command", lambda cmd: recorded.append(cmd))
+    monkeypatch.setattr(gcp_train, "_repo_root", lambda: gcp_train.Path("/repo"))
+
+    args = SimpleNamespace(
+        accelerator="gpu",
+        name="trainer",
+        project="proj",
+        zone="us-central1-a",
+        command="python -m poker_ai.cli.train --gpus",
+        bucket=None,
+    )
+
+    gcp_train.run_training(args)
+
+    sync_cmd, ssh_cmd = recorded
+    assert sync_cmd[:3] == ["gcloud", "compute", "scp"]
+    assert ssh_cmd[:3] == ["gcloud", "compute", "ssh"]
+    assert "--command" in ssh_cmd
+    command_index = ssh_cmd.index("--command") + 1
+    assert ssh_cmd[command_index].endswith("python -m poker_ai.cli.train --gpus")
+
+
+def test_run_training_tpu(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(gcp_train, "ensure_gcloud_available", lambda: None)
+    monkeypatch.setattr(gcp_train, "_run_command", lambda cmd: recorded.append(cmd))
+    monkeypatch.setattr(gcp_train, "_repo_root", lambda: gcp_train.Path("/repo"))
+
+    args = SimpleNamespace(
+        accelerator="tpu",
+        name="trainer",
+        project="proj",
+        zone="us-central1-b",
+        command="python -m poker_ai.cli.train --tpu",
+        bucket="gs://bucket",
+    )
+
+    gcp_train.run_training(args)
+
+    sync_cmd, ssh_cmd = recorded
+    assert sync_cmd[:5] == ["gcloud", "alpha", "compute", "tpus", "tpu-vm"]
+    assert ssh_cmd[:5] == ["gcloud", "alpha", "compute", "tpus", "tpu-vm"]
+    assert "CHECKPOINT_BUCKET" in gcp_train._remote_training_command(args)
+
+
+def test_remote_command_includes_bucket():
+    args = SimpleNamespace(command="run.sh", bucket="gs://foo")
+    command = gcp_train._remote_training_command(args)
+    assert command.startswith("export CHECKPOINT_BUCKET=gs://foo &&")
+    assert command.endswith("run.sh")

--- a/tests/cli/test_train_devices.py
+++ b/tests/cli/test_train_devices.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import builtins
+from types import SimpleNamespace
+
+import pytest
+
+from poker_ai.cli import train
+
+
+class DummyTrainer:
+    def __init__(self) -> None:
+        self.config = {"training": {}}
+        self.saved_models: list[str] = []
+
+    def save_model(self, path: str) -> None:
+        self.saved_models.append(path)
+
+    def load_model(self, path: str | None = None) -> None:  # pragma: no cover - stub
+        return None
+
+
+class DummySelfPlay:
+    def __init__(self, *_, **__) -> None:
+        self.played_iterations: list[int] = []
+
+    def play_hand_for_training(self, iteration: int) -> None:
+        self.played_iterations.append(iteration)
+
+
+class DummyAnalyzer:
+    def __init__(self, *_, **__) -> None:
+        pass
+
+    def on_iteration_end(self, *_, **__) -> None:  # pragma: no cover - stub
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stubbed_components(monkeypatch):
+    monkeypatch.setattr(train, "SelfPlay", DummySelfPlay)
+    monkeypatch.setattr(train, "ModelPerformanceAnalyzer", DummyAnalyzer)
+    monkeypatch.setattr(train, "_find_latest_model_path", lambda *_, **__: None)
+
+
+def _base_config() -> dict:
+    return {
+        "training": {
+            "num_training_hands": 1,
+            "save_model_every_samples": 0,
+            "save_model_every_n_hands": 0,
+            "save_model_every_minutes": 0,
+            "min_buffer_before_train": 128,
+        },
+        "game_engine": {
+            "min_players": 2,
+            "max_players": 2,
+            "starting_stack": 1000,
+            "big_blind": 10,
+            "small_blind": 5,
+        },
+        "curriculum": {"stages": []},
+    }
+
+
+def _make_args(**overrides):
+    defaults = dict(
+        algorithm="deep_cfr",
+        gpus=False,
+        npus=False,
+        tpu=False,
+        num_hands=None,
+        save_model_every=None,
+        save_minutes=None,
+        save_samples=None,
+        min_buffer_before_train=None,
+        config=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _run_main(monkeypatch, args, torch_cuda=None, torch_npu=None):
+    captured: dict[str, object] = {}
+
+    def fake_parse_args():
+        return args
+
+    def fake_initialize(algorithm, config, device, *, use_data_parallel):
+        captured.update(
+            algorithm=algorithm,
+            config=config,
+            device=device,
+            use_data_parallel=use_data_parallel,
+        )
+        return DummyTrainer()
+
+    monkeypatch.setattr(train, "parse_args", fake_parse_args)
+    monkeypatch.setattr(train, "load_configuration", lambda *_: _base_config())
+    monkeypatch.setattr(train, "initialize_trainer", fake_initialize)
+
+    if torch_cuda is not None:
+        monkeypatch.setattr(train.torch, "cuda", torch_cuda, raising=False)
+    if torch_npu is not None:
+        monkeypatch.setattr(train.torch, "npu", torch_npu, raising=False)
+
+    monkeypatch.setattr(train.os, "makedirs", lambda *_, **__: None)
+
+    train.main()
+    return captured
+
+
+class _CudaStub:
+    def __init__(self, available: bool, count: int = 1) -> None:
+        self._available = available
+        self._count = count
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def device_count(self) -> int:
+        return self._count
+
+
+class _NPUStub:
+    def __init__(self, available: bool, count: int = 1) -> None:
+        self._available = available
+        self._count = count
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def device_count(self) -> int:
+        return self._count
+
+
+def test_gpu_multi_device(monkeypatch, capsys):
+    args = _make_args(gpus=True)
+    captured = _run_main(monkeypatch, args, torch_cuda=_CudaStub(True, count=2))
+
+    out = capsys.readouterr().out
+    assert "Multi-GPU training enabled. Found 2 GPUs." in out
+    assert captured["device"] == "cuda"
+    assert captured["use_data_parallel"] is True
+
+
+def test_gpu_fallback_to_cpu(monkeypatch, capsys):
+    args = _make_args(gpus=True)
+    captured = _run_main(monkeypatch, args, torch_cuda=_CudaStub(False))
+
+    out = capsys.readouterr().out
+    assert "Warning: --gpus specified, but no GPU devices are available." in out
+    assert captured["device"] == "cpu"
+    assert captured["use_data_parallel"] is False
+
+
+def test_npu_multi_device(monkeypatch, capsys):
+    args = _make_args(npus=True)
+    captured = _run_main(monkeypatch, args, torch_npu=_NPUStub(True, count=3))
+
+    out = capsys.readouterr().out
+    assert "Multi-NPU training enabled. Found 3 NPUs." in out
+    assert captured["device"] == "npu"
+    assert captured["use_data_parallel"] is True
+
+
+def test_npu_fallback_to_cpu(monkeypatch, capsys):
+    args = _make_args(npus=True)
+    captured = _run_main(monkeypatch, args, torch_npu=_NPUStub(False))
+
+    out = capsys.readouterr().out
+    assert "Warning: --npus specified, but no NPU devices are available." in out
+    assert captured["device"] == "cpu"
+    assert captured["use_data_parallel"] is False
+
+
+def test_tpu_requires_torch_xla(monkeypatch):
+    args = _make_args(tpu=True)
+
+    def fake_import(name, *args, **kwargs):
+        if name == "torch_xla.core.xla_model":
+            raise ImportError("no module named torch_xla")
+        return original_import(name, *args, **kwargs)
+
+    original_import = builtins.__import__
+    monkeypatch.setattr(train, "parse_args", lambda: args)
+    monkeypatch.setattr(train, "load_configuration", lambda *_: _base_config())
+    monkeypatch.setattr(train, "initialize_trainer", lambda *_, **__: DummyTrainer())
+    monkeypatch.setattr(train, "SelfPlay", DummySelfPlay)
+    monkeypatch.setattr(train, "ModelPerformanceAnalyzer", DummyAnalyzer)
+    monkeypatch.setattr(train, "_find_latest_model_path", lambda *_, **__: None)
+    monkeypatch.setattr(train.os, "makedirs", lambda *_, **__: None)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        train.main()
+
+    assert "torch_xla is required for TPU training" in str(excinfo.value)

--- a/tests/gui/test_card_assets.py
+++ b/tests/gui/test_card_assets.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from verify_images import (
+    DEFAULT_CARD_DIRECTORY,
+    DEFAULT_TABLE_BACKGROUND,
+    inspect_card_assets,
+    inspect_table_background,
+)
+
+
+def test_card_images_complete():
+    report = inspect_card_assets()
+    assert report.directory_exists, f"Card directory missing: {DEFAULT_CARD_DIRECTORY}"
+    assert report.missing_cards == []
+    assert report.unexpected_files == []
+    assert report.found == report.total_expected
+    assert all(size > 0 for size in report.file_sizes.values())
+
+
+def test_table_background_exists():
+    report = inspect_table_background()
+    assert report.exists, f"Expected poker table background at {DEFAULT_TABLE_BACKGROUND}"
+    assert report.size_bytes is not None and report.size_bytes > 0

--- a/tests/tools/test_google_accelerator_train.py
+++ b/tests/tools/test_google_accelerator_train.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tools import google_accelerator_train as helper
+
+
+def test_install_gpu_packages(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(helper, "_run_command", lambda cmd, **kw: recorded.append((cmd, kw)))
+    args = SimpleNamespace(
+        torch_version="2.1.0",
+        torchvision_version="0.16.0",
+        torchaudio_version="2.1.0",
+        torch_index_url="https://download.pytorch.org/whl/cu121",
+        extra_pip_args=["--extra-index-url", "https://example.com/wheels"],
+    )
+    helper._install_gpu_packages(args, dry_run=False)
+    command, kwargs = recorded[0]
+    assert command[:4] == [helper.sys.executable, "-m", "pip", "install"]
+    assert "--extra-index-url" in command
+    assert kwargs == {"dry_run": False}
+
+
+def test_install_tpu_packages(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(helper, "_run_command", lambda cmd, **kw: recorded.append((cmd, kw)))
+    args = SimpleNamespace(
+        torch_version="2.1.0",
+        torchvision_version="0.16.0",
+        torch_xla_version="2.1.0",
+        tpu_wheel_url="https://storage.googleapis.com/tpu-pytorch/wheels.html",
+        extra_pip_args=None,
+    )
+    helper._install_tpu_packages(args, dry_run=True)
+    command, kwargs = recorded[0]
+    assert "torch-xla==2.1.0" in command
+    assert "-f" in command
+    assert kwargs == {"dry_run": True}
+
+
+def test_build_training_command_gpu():
+    args = SimpleNamespace(
+        accelerator="gpu",
+        algorithm="deep_cfr",
+        num_hands=100,
+        config="config.yaml",
+        save_model_every=10,
+        train_args="--min-buffer-before-train 64",
+    )
+    command = helper._build_training_command(args)
+    assert "--gpus" in command
+    assert command.count("--num-hands") == 1
+    assert command[-2:] == ["--min-buffer-before-train", "64"]
+
+
+def test_build_training_command_tpu():
+    args = SimpleNamespace(
+        accelerator="tpu",
+        algorithm=None,
+        num_hands=None,
+        config=None,
+        save_model_every=None,
+        train_args=None,
+    )
+    command = helper._build_training_command(args)
+    assert command[-1] == "--tpu"
+
+
+def test_run_command_dry_run(monkeypatch):
+    recorded = []
+
+    def fake_run(cmd, check=True, env=None):  # pragma: no cover - should not run
+        recorded.append((cmd, env))
+
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+    helper._run_command(["echo", "hello"], dry_run=True)
+    assert recorded == []
+
+
+def test_run_command_executes(monkeypatch):
+    recorded = []
+
+    def fake_run(cmd, check=True, env=None):
+        recorded.append((cmd, env))
+
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+    helper._run_command(["echo", "hello"], dry_run=False)
+    assert recorded[0][0] == ["echo", "hello"]
+
+
+def test_main_installs_and_runs(monkeypatch):
+    recorded = []
+
+    def fake_install_base(*, dry_run):
+        recorded.append(("base", dry_run))
+
+    def fake_install_accelerator(args, *, dry_run):
+        recorded.append((args.accelerator, dry_run))
+
+    def fake_run_command(command, *, env, dry_run):
+        recorded.append(("run", command, env, dry_run))
+
+    monkeypatch.setattr(helper, "_install_base_requirements", fake_install_base)
+    monkeypatch.setattr(helper, "_install_gpu_packages", fake_install_accelerator)
+    monkeypatch.setattr(helper, "_install_tpu_packages", fake_install_accelerator)
+    monkeypatch.setattr(helper, "_run_command", fake_run_command)
+    monkeypatch.setattr(helper.os, "environ", {"PATH": "/usr/bin"})
+
+    args = SimpleNamespace(
+        accelerator="gpu",
+        install_deps=True,
+        bucket="gs://bucket",
+        dry_run=True,
+        algorithm="deep_cfr",
+        num_hands=None,
+        config=None,
+        save_model_every=None,
+        train_args=None,
+    )
+
+    monkeypatch.setattr(helper, "parse_args", lambda _: args)
+    helper.main([])
+
+    assert recorded[0] == ("base", True)
+    assert recorded[1][0] == "gpu"
+    assert recorded[-1][0] == "run"
+    assert recorded[-1][2]["CHECKPOINT_BUCKET"] == "gs://bucket"

--- a/verify_images.py
+++ b/verify_images.py
@@ -1,86 +1,156 @@
-#!/usr/bin/env python3
-"""
-Verify that all poker card images are present and properly named
-"""
+"""Utilities for verifying bundled GUI assets."""
+
+from __future__ import annotations
+
 import os
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+DEFAULT_CARD_DIRECTORY = os.path.join("src", "poker_ai", "gui", "card_images")
+DEFAULT_TABLE_BACKGROUND = os.path.join(
+    "src", "poker_ai", "gui", "assets", "poker_table_background.png"
+)
+
+SUITS: tuple[str, ...] = ("h", "d", "c", "s")
+RANKS: tuple[str, ...] = tuple("23456789TJQKA")
+EXPECTED_CARD_FILENAMES: tuple[str, ...] = tuple(
+    f"{rank}{suit}.png" for suit in SUITS for rank in RANKS
+)
 
 
-def verify_card_images():
-    """Verify all 52 card images are present with correct names"""
+@dataclass
+class CardAssetReport:
+    """Structured result describing the card image directory."""
+
+    directory: str
+    directory_exists: bool
+    missing_cards: List[str] = field(default_factory=list)
+    unexpected_files: List[str] = field(default_factory=list)
+    file_sizes: Dict[str, int] = field(default_factory=dict)
+
+    @property
+    def total_expected(self) -> int:
+        return len(EXPECTED_CARD_FILENAMES)
+
+    @property
+    def found(self) -> int:
+        return len(self.file_sizes)
+
+    @property
+    def is_complete(self) -> bool:
+        return self.directory_exists and not self.missing_cards
+
+
+@dataclass
+class TableBackgroundReport:
+    """Information about the poker table background asset."""
+
+    path: str
+    exists: bool
+    size_bytes: int | None = None
+
+
+def inspect_card_assets(card_dir: str | None = None) -> CardAssetReport:
+    """Return a :class:`CardAssetReport` describing the card assets."""
+
+    directory = card_dir or DEFAULT_CARD_DIRECTORY
+    if not os.path.isdir(directory):
+        return CardAssetReport(directory=directory, directory_exists=False)
+
+    file_sizes: Dict[str, int] = {}
+    missing_cards: List[str] = []
+    for filename in EXPECTED_CARD_FILENAMES:
+        path = os.path.join(directory, filename)
+        if os.path.exists(path):
+            file_sizes[filename[:-4]] = os.path.getsize(path)
+        else:
+            missing_cards.append(filename[:-4])
+
+    all_pngs = [f for f in os.listdir(directory) if f.endswith(".png")]
+    unexpected_files = sorted(f for f in all_pngs if f not in EXPECTED_CARD_FILENAMES)
+
+    return CardAssetReport(
+        directory=directory,
+        directory_exists=True,
+        missing_cards=missing_cards,
+        unexpected_files=unexpected_files,
+        file_sizes={name: size for name, size in file_sizes.items()},
+    )
+
+
+def inspect_table_background(path: str | None = None) -> TableBackgroundReport:
+    """Return metadata describing the poker table background asset."""
+
+    background_path = path or DEFAULT_TABLE_BACKGROUND
+    if os.path.exists(background_path):
+        return TableBackgroundReport(
+            path=background_path,
+            exists=True,
+            size_bytes=os.path.getsize(background_path),
+        )
+    return TableBackgroundReport(path=background_path, exists=False)
+
+
+def _warn_on_anomalies(report: CardAssetReport) -> None:
+    for card, size in sorted(report.file_sizes.items()):
+        if size < 100:
+            print(f"⚠️  {card}.png is very small ({size} bytes)")
+        elif size > 50000:
+            print(f"⚠️  {card}.png is very large ({size} bytes)")
+
+
+def verify_card_images(card_dir: str | None = None) -> bool:
+    """Verify all 52 card images are present with correct names."""
+
     print("Verifying poker card images...")
     print("=" * 40)
 
-    suits = ["h", "d", "c", "s"]
-    ranks = ["2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K", "A"]
+    report = inspect_card_assets(card_dir)
 
-    card_dir = "play/card_images"
-
-    if not os.path.exists(card_dir):
-        print(f"❌ Card directory {card_dir} does not exist!")
+    if not report.directory_exists:
+        print(f"❌ Card directory {report.directory} does not exist!")
         return False
 
-    missing_cards = []
-    existing_cards = []
-    file_sizes = {}
+    print(f"✅ Found {report.found}/{report.total_expected} card images")
 
-    for suit in suits:
-        for rank in ranks:
-            card_name = f"{rank}{suit}"
-            file_path = os.path.join(card_dir, f"{card_name}.png")
-
-            if os.path.exists(file_path):
-                existing_cards.append(card_name)
-                file_size = os.path.getsize(file_path)
-                file_sizes[card_name] = file_size
-
-                # Check if file is reasonable size (not empty, not too large)
-                if file_size < 100:
-                    print(f"⚠️  {card_name}.png is very small ({file_size} bytes)")
-                elif file_size > 50000:
-                    print(f"⚠️  {card_name}.png is very large ({file_size} bytes)")
-            else:
-                missing_cards.append(card_name)
-
-    print(f"✅ Found {len(existing_cards)}/52 card images")
-
-    if missing_cards:
-        print(f"❌ Missing {len(missing_cards)} cards:")
-        print(f"   {', '.join(missing_cards[:10])}{'...' if len(missing_cards) > 10 else ''}")
+    if report.missing_cards:
+        missing_preview = ", ".join(report.missing_cards[:10])
+        suffix = "..." if len(report.missing_cards) > 10 else ""
+        print(f"❌ Missing {len(report.missing_cards)} cards:")
+        print(f"   {missing_preview}{suffix}")
         return False
 
-    # Show some examples of what we have
-    example_cards = ["2h", "7d", "Tc", "Jh", "Qs", "Kc", "As"]
+    _warn_on_anomalies(report)
+
     print("\nExample cards with sizes:")
-    for card in example_cards:
-        if card in file_sizes:
-            print(f"   {card}.png: {file_sizes[card]} bytes")
+    for card in ("2h", "7d", "Tc", "Jh", "Qs", "Kc", "As"):
+        size = report.file_sizes.get(card)
+        if size is not None:
+            print(f"   {card}.png: {size} bytes")
 
-    # Check for duplicates or unexpected files
-    all_files = [f for f in os.listdir(card_dir) if f.endswith(".png")]
-    expected_files = [f"{rank}{suit}.png" for suit in suits for rank in ranks]
-
-    unexpected_files = [f for f in all_files if f not in expected_files]
-    if unexpected_files:
-        print(f"\nUnexpected files found: {unexpected_files}")
+    if report.unexpected_files:
+        print(f"\nUnexpected files found: {report.unexpected_files}")
 
     print("\n🎉 SUCCESS! All 52 poker card images are present and ready!")
     return True
 
 
-def check_poker_table_background():
-    """Check if poker table background exists"""
-    bg_path = "play/assets/poker_table_background.png"
-    if os.path.exists(bg_path):
-        size = os.path.getsize(bg_path)
+def check_poker_table_background(path: str | None = None) -> bool:
+    """Check if poker table background exists."""
+
+    report = inspect_table_background(path)
+    if report.exists:
+        size = report.size_bytes or 0
         print(f"✅ Poker table background found ({size} bytes)")
         return True
-    else:
-        print(f"⚠️  Poker table background not found at {bg_path}")
-        return False
+
+    print(f"⚠️  Poker table background not found at {report.path}")
+    return False
 
 
-def main():
-    """Main verification function"""
+def main() -> None:
+    """Run the verification suite as a standalone script."""
+
     print("Poker Image Assets Verification")
     print("=" * 50)
 
@@ -110,5 +180,5 @@ def main():
         print("   python setup_card_images.py")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()


### PR DESCRIPTION
## Summary
- replace the bespoke logic in `run_all_tests.py` with an argparse-driven pytest orchestrator that can optionally trigger e2e, GUI, and performance suites
- refactor `verify_images.py` to expose reusable inspection helpers for card images and the poker table background, and document the automated asset check in the README
- add pytest coverage for accelerator selection in `poker_ai.cli.train`, the gcloud helper CLI, the Google accelerator bootstrap script, and the bundled GUI asset set

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68d910aa8230832aa87376134272a215