### PR TITLE
Switch gameplay to cash table session

### DIFF
--- a/gatc_holdem/engine/cash_table.py
+++ b/gatc_holdem/engine/cash_table.py
@@ -51,6 +51,15 @@ class CashPlayer:
         self.folded = False
         self.all_in = False
 
+    def sit_out(self) -> None:
+        """Mark the player as no longer seated at the table."""
+
+        self.seated = False
+        self.in_hand = False
+        self.folded = True
+        self.all_in = False
+        self.committed = 0.0
+
 
 @dataclass
 class PotLayer:
@@ -302,6 +311,36 @@ class CashTable:
         player.stack += add
         player.bankroll -= add
         return add
+
+    def add_to_stack(self, pid: int, amount: float) -> float:
+        """Move an explicit ``amount`` from bankroll onto the table stack."""
+
+        player = self.players.get(pid)
+        if player is None:
+            raise KeyError(pid)
+        if amount <= 0:
+            return 0.0
+        max_top_up = self.max_buyin_bb * self.big_blind
+        desired = min(max_top_up, player.stack + amount)
+        move = max(0.0, desired - player.stack)
+        move = min(move, player.bankroll)
+        if move <= _EPSILON:
+            return 0.0
+        player.stack += move
+        player.bankroll -= move
+        return move
+
+    def cash_out(self, pid: int) -> float:
+        """Remove a player from the table and return the chips collected."""
+
+        player = self.players.get(pid)
+        if player is None:
+            raise KeyError(pid)
+        chips = player.stack
+        player.bankroll += chips
+        player.stack = 0.0
+        player.sit_out()
+        return chips
 
     @property
     def total_pot(self) -> float:

--- a/src/poker_ai/cli/play.py
+++ b/src/poker_ai/cli/play.py
@@ -146,15 +146,50 @@ def main() -> None:  # noqa: C901
         else:
             player_strategies.append(RandomAIStrategy())
 
-    # Instantiate the game with chosen starting stack
-    game = TexasHoldem(total_players, starting_stack, cast(list[Any], player_strategies))
+    cash_defaults = cfg.get("cash_game", {})
+    base_small_blind = cash_defaults.get(
+        "small_blind", cfg.get("game_engine", {}).get("small_blind", 10)
+    )
+    base_big_blind = cash_defaults.get(
+        "big_blind", cfg.get("game_engine", {}).get("big_blind", 20)
+    )
+    default_buyin_bb = cash_defaults.get("default_buyin_bb")
+    if default_buyin_bb is None:
+        blind_for_buyin = base_big_blind or 1
+        default_buyin_bb = max(1, int(round(starting_stack / float(blind_for_buyin))))
+
+    cash_config = {
+        "small_blind": base_small_blind,
+        "big_blind": base_big_blind,
+        "min_buyin_bb": cash_defaults.get("min_buyin_bb", 40),
+        "max_buyin_bb": cash_defaults.get("max_buyin_bb", 100),
+        "default_buyin_bb": default_buyin_bb,
+        "default_bankroll_buyins": cash_defaults.get("default_bankroll_buyins", 5),
+        "min_bankroll_buyins": cash_defaults.get("min_bankroll_buyins", 1),
+        "max_bankroll_buyins": cash_defaults.get("max_bankroll_buyins", 5),
+        "rake_pct": cash_defaults.get("rake_pct", 0.0),
+        "rake_cap": cash_defaults.get("rake_cap", 0.0),
+        "no_flop_no_drop": cash_defaults.get("no_flop_no_drop", True),
+    }
+
+    # Instantiate the game with chosen starting stack as an initial buy-in
+    game = TexasHoldem(
+        total_players,
+        starting_stack,
+        cast(list[Any], player_strategies),
+        cash_config=cash_config,
+    )
 
     hands_to_play = args.num_hands
     hands_played = 0
 
     try:
         while hands_to_play == 0 or hands_played < hands_to_play:
-            game.play_game()
+            try:
+                game.play_game()
+            except RuntimeError as exc:
+                print(f"Session halted: {exc}")
+                break
             winner_info = getattr(game, "last_winner", None)
             if isinstance(winner_info, list) and winner_info:
                 players = ", ".join(f"Player {idx + 1}" for idx in winner_info)
@@ -164,11 +199,88 @@ def main() -> None:  # noqa: C901
             else:
                 print("Hand Summary: No winner determined.")
             print("\n--- Hand Completed ---")
+            if game.cash_table is not None:
+                table = game.cash_table
+                print("Current table status:")
+                for pid in range(total_players):
+                    player = table.players.get(pid)
+                    stack = int(round(game.rules.player_chips[pid]))
+                    bankroll = int(round(player.bankroll)) if player else 0
+                    status = "Seated" if player and player.seated else "Away"
+                    print(
+                        f"  Player {pid + 1}: stack={stack} | bankroll={bankroll} | status={status}"
+                    )
+                # Allow human players to manage their stacks
+                for pid in range(num_humans):
+                    player = table.players.get(pid)
+                    if player is None or not player.seated:
+                        continue
+                    while True:
+                        prompt = (
+                            f"Player {pid + 1} action (Enter=skip, 'max'=top up to {table.max_buyin_bb}bb, "
+                            "chip amount, or 'leave'): "
+                        )
+                        choice = input(prompt).strip().lower()
+                        if choice == "":
+                            break
+                        if choice == "leave":
+                            payout = game.cash_out_player(pid)
+                            print(
+                                f"Player {pid + 1} cashes out {int(round(payout))} chips and leaves the table."
+                            )
+                            break
+                        if choice == "max":
+                            added = game.rebuy_to_target(pid)
+                            if added > 0:
+                                print(
+                                    f"Player {pid + 1} tops up by {int(round(added))} chips."
+                                )
+                            else:
+                                print("Unable to top up (insufficient bankroll or already at max).")
+                            break
+                        try:
+                            chips = int(choice)
+                        except ValueError:
+                            print("Invalid input. Provide a number, 'max', or 'leave'.")
+                            continue
+                        added = game.rebuy_amount(pid, chips)
+                        if added > 0:
+                            print(
+                                f"Player {pid + 1} adds {int(round(added))} chips to their stack."
+                            )
+                        else:
+                            print("No chips added (check bankroll and table limits).")
+                        break
+
+                # Automatically rebuy AI players if they are bust but have bankroll
+                for pid in range(num_humans, total_players):
+                    player = table.players.get(pid)
+                    if (
+                        player
+                        and player.seated
+                        and player.stack < table.small_blind
+                        and player.bankroll > 0
+                    ):
+                        added = game.rebuy_to_target(pid)
+                        if added > 0:
+                            print(
+                                f"AI Player {pid + 1} auto-top-ups by {int(round(added))} chips."
+                            )
+
             hands_played += 1
             if hands_to_play != 0 and hands_played >= hands_to_play:
                 break
-            print("Resetting chips and starting a new hand.\n")
-            game.reset_for_next_hand()
+
+            if game.cash_table is not None:
+                remaining = [
+                    pid
+                    for pid, player in game.cash_table.players.items()
+                    if player.seated and player.stack > 0
+                ]
+                if not remaining:
+                    print("No seated players with chips remain. Ending session.")
+                    break
+            print("Starting next cash hand...\n")
     except KeyboardInterrupt:
         print("\nSimulation terminated by user.")
         sys.exit()

--- a/src/poker_ai/config/config.yaml
+++ b/src/poker_ai/config/config.yaml
@@ -6,6 +6,17 @@ game_engine:
   small_blind: 10
   big_blind: 20
 
+cash_game:
+  min_buyin_bb: 40
+  max_buyin_bb: 100
+  default_buyin_bb: 100
+  default_bankroll_buyins: 5
+  min_bankroll_buyins: 1
+  max_bankroll_buyins: 5
+  rake_pct: 0.05
+  rake_cap: 5
+  no_flop_no_drop: true
+
 # Training parameters for the CFR algorithm
 training:
   num_training_hands: 2000000 # Total number of hands to simulate for training

--- a/src/poker_ai/engine/texas_holdem.py
+++ b/src/poker_ai/engine/texas_holdem.py
@@ -10,6 +10,7 @@ import os
 import random
 from typing import Optional
 
+from gatc_holdem.engine import CashTable
 from gatc_holdem.engine.rules import min_raise_to
 from gatc_poker.pots import compute_side_pots as gatc_compute_side_pots
 
@@ -323,7 +324,15 @@ class MockPlayer:
 
 
 class TexasHoldem:
-    def __init__(self, num_players, starting_stack=1000, player_strategies=None, verbose=True):
+    def __init__(
+        self,
+        num_players,
+        starting_stack=1000,
+        player_strategies=None,
+        verbose=True,
+        *,
+        cash_config: dict | None = None,
+    ):
         self.rules = TexasHoldemRules(num_players, starting_stack, verbose=verbose)
         self.num_players = num_players
         self.starting_stack = starting_stack
@@ -342,6 +351,11 @@ class TexasHoldem:
         self._pending_showdown_winnings: Optional[dict[int, int]] = None
         if not os.path.exists("data"):
             os.makedirs("data")
+
+        self.cash_config = cash_config or {}
+        self.cash_table: CashTable | None = None
+        if self.cash_config.get("enabled", True):
+            self._initialize_cash_table()
 
     def _log(self, msg: str) -> None:
         if self.verbose:
@@ -375,11 +389,99 @@ class TexasHoldem:
         clone.winner = _copy_winner(self.winner)
         clone.last_winner = _copy_winner(self.last_winner)
 
+        clone.cash_config = self.cash_config
+        clone.cash_table = self.cash_table
+
         return clone
+
+    def _initialize_cash_table(self) -> None:
+        big_blind = self.cash_config.get("big_blind", self.rules.big_blind)
+        small_blind = self.cash_config.get("small_blind", self.rules.small_blind)
+        self.rules.small_blind = small_blind
+        self.rules.big_blind = big_blind
+
+        configured_min = max(1, int(self.cash_config.get("min_buyin_bb", 40)))
+        configured_max = max(configured_min, int(self.cash_config.get("max_buyin_bb", 100)))
+        default_buyin_bb = self.cash_config.get(
+            "default_buyin_bb",
+            max(1, int(round(self.starting_stack / float(big_blind)))) if big_blind else 1,
+        )
+        min_buyin_bb = min(configured_min, default_buyin_bb)
+        min_buyin_bb = max(1, min_buyin_bb)
+        max_buyin_bb = max(configured_max, min_buyin_bb)
+        default_buyin_bb = min(max(default_buyin_bb, min_buyin_bb), max_buyin_bb)
+
+        table_kwargs = {
+            "small_blind": small_blind,
+            "big_blind": big_blind,
+            "min_buyin_bb": min_buyin_bb,
+            "max_buyin_bb": max_buyin_bb,
+            "min_bankroll_buyins": self.cash_config.get("min_bankroll_buyins", 1),
+            "max_bankroll_buyins": self.cash_config.get("max_bankroll_buyins", 5),
+            "rake_pct": self.cash_config.get("rake_pct", 0.0),
+            "rake_cap": self.cash_config.get("rake_cap", 0.0),
+            "no_flop_no_drop": self.cash_config.get("no_flop_no_drop", True),
+        }
+        self.cash_table = CashTable(**table_kwargs)
+
+        default_bankroll_buyins = self.cash_config.get("default_bankroll_buyins", 5)
+
+        bankrolls = self.cash_config.get("bankrolls", {})
+        buyins = self.cash_config.get("buyins", {})
+
+        for pid in range(self.num_players):
+            bankroll = bankrolls.get(pid)
+            if bankroll is None:
+                bankroll = default_bankroll_buyins * default_buyin_bb * big_blind
+            buyin_bb = buyins.get(pid, default_buyin_bb)
+            self.cash_table.seat_player(pid, bankroll=bankroll, buyin_bb=buyin_bb)
+            stack = int(round(self.cash_table.players[pid].stack))
+            self.rules.player_chips[pid] = stack
+            self.rules.active_players[pid] = (
+                self.cash_table.players[pid].seated and stack > 0
+            )
+
+    def _sync_engine_from_cash_table(self) -> None:
+        if self.cash_table is None:
+            return
+        for pid in range(self.num_players):
+            player = self.cash_table.players.get(pid)
+            if player is None or not player.seated:
+                self.rules.player_chips[pid] = 0
+                self.rules.active_players[pid] = False
+                continue
+            stack = int(round(player.stack))
+            self.rules.player_chips[pid] = stack
+            self.rules.active_players[pid] = player.in_hand and stack > 0
+
+    def _sync_cash_table_post_hand(self) -> None:
+        if self.cash_table is None:
+            return
+        for pid in range(self.num_players):
+            chips = max(0.0, float(self.rules.player_chips[pid]))
+            player = self.cash_table.players.get(pid)
+            if player is None:
+                continue
+            player.stack = chips if player.seated else 0.0
+            player.committed = 0.0
+            player.folded = False
+            player.all_in = False
+            player.in_hand = False
+        self.cash_table.button_idx = self.rules.dealer_button
 
     def initialize_game(self):
         # Reset game state for new hand
         self.last_winner = None
+        if self.cash_table is not None:
+            active_players = [
+                pid
+                for pid, player in self.cash_table.players.items()
+                if player.seated and player.stack > 0
+            ]
+            if not active_players:
+                raise RuntimeError("No seated players with chips to start a hand")
+            self.cash_table.start_hand(active_players)
+            self._sync_engine_from_cash_table()
         self.rules.hands = [[] for _ in range(self.num_players)]
         self.rules.community_cards = []
         self.rules.pot = 0
@@ -959,8 +1061,25 @@ class TexasHoldem:
         """
 
         # Update active players based on remaining chips and rotate the dealer
-        self.rules.active_players = [chips > 0 for chips in self.rules.player_chips]
-        self.rules.dealer_button = (self.rules.dealer_button + 1) % self.num_players
+        if self.cash_table is not None:
+            self._sync_cash_table_post_hand()
+            for pid in range(self.num_players):
+                player = self.cash_table.players.get(pid)
+                if player is None or not player.seated:
+                    self.rules.player_chips[pid] = 0
+                    self.rules.active_players[pid] = False
+                else:
+                    stack = int(round(player.stack))
+                    self.rules.player_chips[pid] = stack
+                    self.rules.active_players[pid] = stack > 0
+            next_dealer = self.rules._next_player_with_chips(self.rules.dealer_button)
+            if next_dealer is None:
+                next_dealer = self.rules.dealer_button
+            self.rules.dealer_button = next_dealer
+            self.cash_table.button_idx = self.rules.dealer_button
+        else:
+            self.rules.active_players = [chips > 0 for chips in self.rules.player_chips]
+            self.rules.dealer_button = (self.rules.dealer_button + 1) % self.num_players
 
         # Reset game state
         self.rules.deck = self.rules._create_deck()
@@ -1201,9 +1320,63 @@ class TexasHoldem:
     def display_player_chips(self):
         self._log("\n--- Player Chip Counts ---")
         for i in range(self.num_players):
-            status = "Active" if self.rules.active_players[i] else "Eliminated"
-            self._log(f"Player {i + 1}: {self.rules.player_chips[i]} chips ({status})")
+            status = "Active" if self.rules.active_players[i] else "Sitting out"
+            bankroll_info = ""
+            if self.cash_table is not None:
+                player = self.cash_table.players.get(i)
+                if player is not None:
+                    bankroll_info = f" | Bankroll: {int(round(player.bankroll))}"
+                    if not player.seated:
+                        status = "Left table"
+            self._log(
+                f"Player {i + 1}: {self.rules.player_chips[i]} chips ({status}){bankroll_info}"
+            )
         self._log("---------------------------\n")
+
+    def rebuy_to_target(self, player_index: int, target_bb: int | None = None) -> float:
+        if self.cash_table is None:
+            return 0.0
+        player = self.cash_table.players.get(player_index)
+        if player is None or not player.seated:
+            return 0.0
+        if target_bb is None:
+            target_bb = self.cash_table.max_buyin_bb
+        added = self.cash_table.top_up(player_index, target_bb)
+        if added > 0:
+            self.rules.player_chips[player_index] = int(
+                round(self.cash_table.players[player_index].stack)
+            )
+            self.rules.active_players[player_index] = True
+        return added
+
+    def rebuy_amount(self, player_index: int, amount: float) -> float:
+        if self.cash_table is None:
+            return 0.0
+        added = self.cash_table.add_to_stack(player_index, amount)
+        if added > 0:
+            stack = int(round(self.cash_table.players[player_index].stack))
+            self.rules.player_chips[player_index] = stack
+            self.rules.active_players[player_index] = stack > 0
+        return added
+
+    def cash_out_player(self, player_index: int) -> float:
+        if self.cash_table is None:
+            return 0.0
+        player = self.cash_table.players.get(player_index)
+        if player is None:
+            return 0.0
+        payout = self.cash_table.cash_out(player_index)
+        self.rules.player_chips[player_index] = 0
+        self.rules.active_players[player_index] = False
+        return payout
+
+    def player_bankroll(self, player_index: int) -> float:
+        if self.cash_table is None:
+            return float(self.rules.player_chips[player_index])
+        player = self.cash_table.players.get(player_index)
+        if player is None:
+            return 0.0
+        return player.bankroll
 
     def show_player_hands(self):
         for i in range(self.num_players):

--- a/src/poker_ai/gui/gui.py
+++ b/src/poker_ai/gui/gui.py
@@ -710,8 +710,10 @@ class PokerGameGUI:
     def next_hand(self):
         """Start the next hand."""
         if self.game:
-            self.game.reset_for_next_hand()
-            self.play_hand()
+            try:
+                self.play_hand()
+            except RuntimeError as exc:
+                messagebox.showinfo("Table Closed", str(exc))
 
     def run(self):
         """Start the GUI main loop."""

--- a/tests/test_engine_integration.py
+++ b/tests/test_engine_integration.py
@@ -16,3 +16,20 @@ def test_engine_initialization():
     assert len(game.rules.hands[0]) == 2
     assert len(game.rules.hands[1]) == 2
     assert game.rules.pot == game.rules.small_blind + game.rules.big_blind
+
+
+def test_cash_rebuy_and_cashout():
+    game = TexasHoldem(num_players=2, starting_stack=100, verbose=False)
+    assert game.cash_table is not None
+    table = game.cash_table
+    # Simulate a bust and rebuy
+    game.rules.player_chips[0] = 0
+    table.players[0].stack = 0.0
+    added = game.rebuy_to_target(0, target_bb=5)
+    assert added > 0
+    assert int(round(table.players[0].stack)) == game.rules.player_chips[0]
+
+    # Cash the player out and ensure they leave the table
+    payout = game.cash_out_player(0)
+    assert payout > 0
+    assert not table.players[0].seated


### PR DESCRIPTION
## Summary
- integrate the existing CashTable module with the TexasHoldem engine to manage stacks, bankrolls, and table rotation between hands
- update the CLI workflow and defaults to run as a cash game, including interactive rebuys, automated AI top ups, and cash-outs
- expose cash-game configuration defaults and add regression coverage for rebuy/cash-out behaviour

## Testing
- pytest tests/test_engine_integration.py

------
https://chatgpt.com/codex/tasks/task_b_68d7d4d94994832ab2343d5919bb9791