### PR TITLE
Ensure GUI resets engine when advancing to next hand

### DIFF
--- a/src/poker_ai/gui/gui.py
+++ b/src/poker_ai/gui/gui.py
@@ -709,11 +709,26 @@ class PokerGameGUI:
 
     def next_hand(self):
         """Start the next hand."""
-        if self.game:
-            try:
-                self.play_hand()
-            except RuntimeError as exc:
-                messagebox.showinfo("Table Closed", str(exc))
+        if not self.game:
+            return
+
+        try:
+            reset_method = getattr(self.game, "reset_for_next_hand", None)
+            if callable(reset_method):
+                reset_method()
+        except RuntimeError as exc:
+            # Surface engine level errors to the player but keep the GUI usable.
+            messagebox.showinfo("Table Closed", str(exc))
+            return
+
+        # Refresh the GUI so the player can see the new hand being dealt.
+        self.status_label.config(text="Dealing next hand...")
+        self.update_display()
+
+        try:
+            self.play_hand()
+        except RuntimeError as exc:
+            messagebox.showinfo("Table Closed", str(exc))
 
     def run(self):
         """Start the GUI main loop."""


### PR DESCRIPTION
## Summary
- call the engine's reset_for_next_hand hook before starting a new hand from the GUI
- refresh the status label and display after resetting so the next hand is clearly shown
- keep existing runtime error handling so the table can be closed gracefully

## Testing
- pytest tests/test_gui_functionality.py::TestPokerGameGUIFunctionality::test_05_play_hand_and_next_hand -q
- pytest tests -q

------
https://chatgpt.com/codex/tasks/task_b_68d91d88a78c832a8452eedd17434c81