### PR TITLE
Ensure CFR trainer applies opponent reach weighting

### DIFF
--- a/src/poker_ai/ai/trainers/ai_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/ai_cfr_trainer.py
@@ -189,6 +189,7 @@ class AICFRTrainer:
         history_tensor: torch.Tensor,
         all_counterfactual_payoffs: torch.Tensor,
         mask: torch.Tensor | None = None,
+        opponent_reach: float = 1.0,
     ) -> float:
         """Train the model for one infoset and return the loss."""
 
@@ -247,6 +248,8 @@ class AICFRTrainer:
             action_regrets = payoffs - state_value
             if legal_mask is not None:
                 action_regrets = torch.where(legal_mask, action_regrets, torch.zeros_like(action_regrets))
+            reach_tensor = payoffs.new_tensor(float(opponent_reach))
+            action_regrets = action_regrets * reach_tensor
 
             cumulative_regret = update_regret(cumulative_regret, action_regrets)
             current_regret_matched_policy = calculate_strategy(
@@ -283,7 +286,14 @@ class AICFRTrainer:
             return 0.0
 
         losses: list[float] = []
-        for hole, community, history, payoffs, legal_mask, _iteration in batch:
+        for entry in batch:
+            opponent_reach = 1.0
+            if len(entry) == 7:
+                hole, community, history, payoffs, legal_mask, opponent_reach, _iteration = entry
+            elif len(entry) == 6:
+                hole, community, history, payoffs, legal_mask, _iteration = entry
+            else:  # pragma: no cover - defensive guard for unexpected buffer format
+                raise ValueError("Unexpected replay buffer entry format")
             info_set_id = self._build_info_set_id(hole, community, history)
             loss = self._train_single(
                 info_set_id,
@@ -292,6 +302,7 @@ class AICFRTrainer:
                 history,
                 payoffs,
                 mask=legal_mask,
+                opponent_reach=float(opponent_reach),
             )
             if loss is not None:
                 losses.append(float(loss))
@@ -389,23 +400,31 @@ class AICFRReplayBuffer:
         self.capacity = capacity
         self.buffer: list[tuple[torch.Tensor, ...]] = []
 
-    def push(self, *args: torch.Tensor | int) -> None:
-        if len(args) < 5:
-            raise TypeError("push expects at least 5 arguments")
-
-        hole, community, history, target, *remaining = args  # type: ignore[misc]
-        iteration = int(remaining.pop()) if remaining else 0
-        counterfactual_values = remaining.pop(0) if remaining else target
-        legal_mask = remaining.pop(0) if remaining else None
-
-        hole_cpu = hole.detach().cpu()
-        community_cpu = community.detach().cpu()
-        history_cpu = history.detach().cpu()
+    def push(
+        self,
+        hole_summary: torch.Tensor,
+        community_summary: torch.Tensor,
+        history_tensor: torch.Tensor,
+        counterfactual_values: torch.Tensor,
+        legal_mask: torch.Tensor | None = None,
+        iteration: int = 0,
+        *,
+        opponent_reach: float | torch.Tensor = 1.0,
+    ) -> None:
+        hole_cpu = hole_summary.detach().cpu()
+        community_cpu = community_summary.detach().cpu()
+        history_cpu = history_tensor.detach().cpu()
         cf_cpu = counterfactual_values.detach().cpu()
+
         if legal_mask is None:
             mask_cpu = torch.ones_like(cf_cpu, dtype=torch.bool)
         else:
             mask_cpu = legal_mask.detach().cpu().bool()
+
+        if torch.is_tensor(opponent_reach):
+            reach_value = float(opponent_reach.detach().cpu().item())
+        else:
+            reach_value = float(opponent_reach)
 
         entry = (
             hole_cpu,
@@ -413,6 +432,7 @@ class AICFRReplayBuffer:
             history_cpu,
             cf_cpu,
             mask_cpu,
+            reach_value,
             int(iteration),
         )
 

--- a/src/poker_ai/selfplay/self_play.py
+++ b/src/poker_ai/selfplay/self_play.py
@@ -507,14 +507,18 @@ class SelfPlay:
                         hole_s,
                         community_s,
                         state_tensor,
-                        weighted_regrets,
                         action_utilities.detach().clone(),
-                        legal_actions_mask,
-                        iteration,
+                        legal_mask=legal_actions_mask,
+                        opponent_reach=opponent_reach,
+                        iteration=iteration,
                     )
                 except TypeError:
                     self.cfr_trainer.replay_buffer.push(
-                        hole_s, community_s, state_tensor, weighted_regrets, iteration
+                        hole_s,
+                        community_s,
+                        state_tensor,
+                        weighted_regrets,
+                        iteration,
                     )
 
             return node_value

--- a/tests/test_ai_cfr_trainer.py
+++ b/tests/test_ai_cfr_trainer.py
@@ -1,0 +1,74 @@
+import torch
+
+from poker_ai.ai.trainers.ai_cfr_trainer import AICFRTrainer, AICFRReplayBuffer
+
+
+class _ConstantLogitModel(torch.nn.Module):
+    def __init__(self, num_actions: int) -> None:
+        super().__init__()
+        # Parameter so that optimizers expecting parameters still function.
+        self.logits = torch.nn.Parameter(torch.zeros(num_actions))
+
+    def forward(
+        self,
+        hole_summary: torch.Tensor,
+        community_summary: torch.Tensor,
+        history_seq: torch.Tensor,
+        src_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        batch = hole_summary.shape[0]
+        return self.logits.expand(batch, -1)
+
+
+def test_train_single_scales_regrets_by_opponent_reach() -> None:
+    trainer = AICFRTrainer(device="cpu")
+    trainer.model = _ConstantLogitModel(trainer.num_actions)
+    trainer.model.to(trainer.device)
+    trainer.optimizer = torch.optim.SGD(trainer.model.parameters(), lr=0.0)
+
+    hole = torch.zeros(trainer.card_feature_dim)
+    community = torch.zeros(trainer.card_feature_dim)
+    history = torch.zeros(trainer.max_seq_len, trainer.history_feature_dim)
+    payoffs = torch.linspace(-1.0, 1.0, steps=trainer.num_actions)
+
+    opponent_reach = 0.25
+    info_set_id = "test_infoset"
+
+    trainer._train_single(
+        info_set_id,
+        hole,
+        community,
+        history,
+        payoffs,
+        opponent_reach=opponent_reach,
+    )
+
+    stored_regrets = trainer.cumulative_regret[info_set_id].detach().cpu()
+    mean_payoff = payoffs.mean()
+    expected = (payoffs - mean_payoff) * opponent_reach
+    assert torch.allclose(stored_regrets, expected, atol=1e-6)
+
+
+def test_replay_buffer_records_opponent_reach() -> None:
+    buffer = AICFRReplayBuffer(capacity=2)
+    hole = torch.zeros(2)
+    community = torch.zeros(2)
+    history = torch.zeros(1, 2)
+    payoffs = torch.tensor([0.1, 0.2, 0.3])
+    legal_mask = torch.tensor([True, False, True])
+
+    buffer.push(
+        hole,
+        community,
+        history,
+        payoffs,
+        legal_mask=legal_mask,
+        opponent_reach=0.6,
+        iteration=7,
+    )
+
+    entry = buffer.sample(1)[0]
+    assert len(entry) == 7
+    # Opponent reach should be preserved as a plain float for lightweight storage.
+    assert entry[5] == 0.6
+    assert entry[6] == 7


### PR DESCRIPTION
## Summary
- scale AICFRTrainer regrets by the opponent reach and store the reach value in replay buffer entries
- forward opponent reach from self-play to the trainer while keeping the legacy positional push fallback
- add unit tests covering regret scaling and replay buffer opponent reach storage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68da050a532c832a8d3bfb4e9dacb41a