### PR TITLE
Add regression tests for GUI strategies and monitoring hooks

### DIFF
--- a/tests/evaluation/test_ai_gto_analyzer.py
+++ b/tests/evaluation/test_ai_gto_analyzer.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import traceback
+
+import pytest
+
+from poker_ai.evaluation import ai_gto_analyzer
+
+
+@pytest.fixture(autouse=True)
+def reset_analyzer_state():
+    ai_gto_analyzer._loaded_cfr_trainer = None
+    ai_gto_analyzer._trainer_config = {
+        "num_actions": 4,
+        "input_shape": (1, 1, 1),
+        "learning_rate": 0.01,
+    }
+    ai_gto_analyzer._full_config = {
+        "model": {"directory": "trained_models", "num_actions": 4},
+        "training": {"save_model_path": "trained_models/cfr_model.pth"},
+    }
+
+
+class DummyModel:
+    def __init__(self) -> None:
+        self.eval_calls = 0
+
+    def eval(self) -> None:
+        self.eval_calls += 1
+
+
+class DummyTrainer:
+    init_calls = 0
+
+    def __init__(self, config):  # noqa: ANN001 - signature dictated by analyzer
+        DummyTrainer.init_calls += 1
+        self.config = config
+        self.model = DummyModel()
+        self.load_calls = 0
+        self.model_path = None
+
+    def load_model(self, path):  # noqa: ANN001
+        self.load_calls += 1
+        self.model_path = path
+        return True
+
+    def encode_state(self, game):  # noqa: ANN001
+        return "encoded"
+
+    def get_strategy(self, state):  # noqa: ANN001
+        return [0.1, 0.2, 0.3, 0.4]
+
+
+def test_load_cfr_model_caches_trainer(monkeypatch):
+    DummyTrainer.init_calls = 0
+    monkeypatch.setattr(ai_gto_analyzer, "CFRTrainer", DummyTrainer)
+    monkeypatch.setattr(ai_gto_analyzer.os, "makedirs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ai_gto_analyzer.os.path, "exists", lambda path: True)
+
+    trainer1, config1 = ai_gto_analyzer.load_cfr_model_and_config("trained_models/cfr_model.pth")
+    trainer2, config2 = ai_gto_analyzer.load_cfr_model_and_config("trained_models/cfr_model.pth")
+
+    assert trainer1 is trainer2
+    assert config1 == config2
+    assert trainer1.model.eval_calls == 1
+    assert trainer1.load_calls == 1
+    assert DummyTrainer.init_calls == 1
+
+
+def test_load_cfr_model_handles_missing_file(monkeypatch, capsys):
+    monkeypatch.setattr(ai_gto_analyzer, "CFRTrainer", DummyTrainer)
+    monkeypatch.setattr(ai_gto_analyzer.os, "makedirs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ai_gto_analyzer.os.path, "exists", lambda path: False)
+
+    trainer, config = ai_gto_analyzer.load_cfr_model_and_config("trained_models/missing.pth")
+
+    captured = capsys.readouterr().out
+    assert "AI model file not found" in captured
+    assert trainer is None
+    assert config == ai_gto_analyzer._trainer_config
+
+
+def test_display_ai_gto_stats_formats_probabilities(monkeypatch, capsys):
+    trainer = DummyTrainer(ai_gto_analyzer._trainer_config)
+
+    def _fake_loader(_path):
+        return trainer, ai_gto_analyzer._trainer_config
+
+    monkeypatch.setattr(ai_gto_analyzer, "load_cfr_model_and_config", _fake_loader)
+    monkeypatch.setattr(ai_gto_analyzer, "action_to_tuple", lambda action: action)
+    monkeypatch.setattr(
+        ai_gto_analyzer,
+        "get_action_from_index",
+        lambda idx, *_args, **_kwargs: (
+            ("fold", None),
+            ("check", None),
+            ("call", 20),
+            ("raise", 60),
+        )[idx],
+    )
+
+    class Rules:
+        def __init__(self):
+            self.pot = 150
+            self.current_bet = 40
+            self.bets = [10, 0]
+            self.player_chips = [200, 300]
+
+    class Game:
+        def __init__(self):
+            self.rules = Rules()
+
+    ai_gto_analyzer.display_ai_gto_stats(Game(), 0)
+    output = capsys.readouterr().out
+
+    assert "Fold: 10.0%" in output
+    assert "Check: 20.0%" in output
+    assert "Call 30 chips" in output
+    assert "Raise to 60" in output
+
+
+def test_display_ai_gto_stats_logs_errors(monkeypatch, capsys):
+    class ErrorTrainer(DummyTrainer):
+        def get_strategy(self, state):  # noqa: ANN001
+            raise RuntimeError("boom")
+
+    trainer = ErrorTrainer(ai_gto_analyzer._trainer_config)
+
+    def _fake_loader(_path):
+        return trainer, ai_gto_analyzer._trainer_config
+
+    monkeypatch.setattr(ai_gto_analyzer, "load_cfr_model_and_config", _fake_loader)
+    monkeypatch.setattr(traceback, "print_exc", lambda: None)
+    monkeypatch.setattr(ai_gto_analyzer, "action_to_tuple", lambda action: action)
+    monkeypatch.setattr(
+        ai_gto_analyzer,
+        "get_action_from_index",
+        lambda *_args, **_kwargs: ("fold", None),
+    )
+
+    class Game:
+        def __init__(self):
+            class Rules:
+                pot = 0
+                current_bet = 0
+                bets = [0]
+                player_chips = [0]
+
+            self.rules = Rules()
+
+    ai_gto_analyzer.display_ai_gto_stats(Game(), 0)
+    output = capsys.readouterr().out
+    assert "Error during AI GTO analysis" in output

--- a/tests/gui/test_human_strategy.py
+++ b/tests/gui/test_human_strategy.py
@@ -1,0 +1,83 @@
+import builtins
+
+import pytest
+
+from poker_ai.gui.playStrategy import HumanStrategy
+
+
+class FakeRules:
+    def __init__(self, pot, current_bet, bets, player_chips):
+        self.pot = pot
+        self.current_bet = current_bet
+        self.bets = list(bets)
+        self.player_chips = list(player_chips)
+
+
+class FakeGame:
+    def __init__(self, rules, valid_actions, min_raise, max_raise):
+        self.rules = rules
+        self._valid_actions = list(valid_actions)
+        self._min_raise = min_raise
+        self._max_raise = max_raise
+
+    def get_valid_actions(self, player_index):
+        return list(self._valid_actions)
+
+    def get_min_raise_amount(self, player_index):
+        return self._min_raise
+
+    def get_max_raise_amount(self, player_index):
+        return self._max_raise
+
+
+@pytest.fixture(autouse=True)
+def reset_display_cache(monkeypatch):
+    # Ensure each test controls the optional analyzer hook explicitly.
+    monkeypatch.setattr("poker_ai.evaluation.display_ai_gto_stats", None, raising=False)
+
+
+def _set_inputs(monkeypatch, responses):
+    iterator = iter(responses)
+
+    def _fake_input(_prompt=""):
+        try:
+            return next(iterator)
+        except StopIteration as exc:  # pragma: no cover - defensive
+            raise AssertionError("Input requested more times than expected") from exc
+
+    monkeypatch.setattr(builtins, "input", _fake_input)
+
+
+def test_choose_action_handles_raise_validation_and_optional_display(monkeypatch):
+    calls: list[tuple[object, int]] = []
+    monkeypatch.setattr(
+        "poker_ai.evaluation.display_ai_gto_stats",
+        lambda game, idx: calls.append((game, idx)),
+        raising=False,
+    )
+
+    rules = FakeRules(pot=150, current_bet=20, bets=[0, 0], player_chips=[200, 150])
+    game = FakeGame(rules, ["raise", "call", "fold"], min_raise=30, max_raise=80)
+    _set_inputs(monkeypatch, ["raise", "abc", "25", "60"])
+
+    action, amount = HumanStrategy().choose_action(game, 0)
+
+    assert action == "raise"
+    assert amount == 60
+    assert calls == [(game, 0)]
+
+
+def test_choose_action_returns_simple_actions_when_display_missing(monkeypatch):
+    rules = FakeRules(pot=75, current_bet=15, bets=[15, 0], player_chips=[85, 120])
+    game = FakeGame(rules, ["call", "fold"], min_raise=20, max_raise=40)
+    _set_inputs(monkeypatch, ["call"])
+
+    assert HumanStrategy().choose_action(game, 0) == ("call", None)
+
+
+def test_choose_action_reprompts_when_raise_not_allowed(monkeypatch):
+    rules = FakeRules(pot=90, current_bet=30, bets=[0, 0], player_chips=[40, 120])
+    game = FakeGame(rules, ["raise", "call", "fold"], min_raise=50, max_raise=40)
+    _set_inputs(monkeypatch, ["raise", "call"])
+
+    assert HumanStrategy().choose_action(game, 0) == ("call", None)

--- a/tests/gui/test_model_ai_strategy.py
+++ b/tests/gui/test_model_ai_strategy.py
@@ -1,0 +1,137 @@
+import types
+
+import pytest
+import torch
+
+from poker_ai.ai.models.transformer import AdvantageNetwork
+from poker_ai.gui.playStrategy import ModelAIStrategy
+
+
+@pytest.fixture(autouse=True)
+def restore_helpers(monkeypatch):
+    # Ensure utility functions are controlled per-test without leaking state.
+    monkeypatch.setattr(
+        "poker_ai.gui.playStrategy.prepare_transformer_input",
+        lambda *_args, **_kwargs: (
+            torch.zeros(2, dtype=torch.float32),
+            torch.zeros(2, dtype=torch.float32),
+            torch.zeros(2, 1, dtype=torch.float32),
+        ),
+    )
+    monkeypatch.setattr(
+        "poker_ai.gui.playStrategy.infer_normalization_scale",
+        lambda *args, **kwargs: 1.0,
+    )
+
+
+def _make_model(num_actions: int, output: torch.Tensor) -> AdvantageNetwork:
+    model = AdvantageNetwork(
+        history_feature_dim=1,
+        card_feature_dim=1,
+        hidden_dim=1,
+        num_heads=1,
+        num_layers=1,
+        num_actions=num_actions,
+    )
+
+    def _forward(self, *args, **kwargs):  # noqa: ANN001, ANN002 - test stub
+        return output
+
+    model.forward = types.MethodType(_forward, model)
+    return model
+
+
+def test_model_ai_strategy_prefers_best_legal_action(monkeypatch):
+    torch.manual_seed(0)
+    output = torch.tensor([3.0, 10.0, 2.0, 1.0])
+    model = _make_model(4, output)
+
+    mask = torch.tensor([True, False, True, False])
+    captured = {}
+
+    monkeypatch.setattr(
+        "poker_ai.gui.playStrategy.get_legal_actions_mask",
+        lambda *_args, **_kwargs: mask,
+    )
+    monkeypatch.setattr(
+        "poker_ai.gui.playStrategy.get_action_from_index",
+        lambda idx, *_args, **_kwargs: {0: "call", 2: "raise"}[idx],
+    )
+    monkeypatch.setattr(
+        "poker_ai.gui.playStrategy.action_to_tuple",
+        lambda action: (action, None if action != "raise" else 50),
+    )
+
+    def _fake_multinomial(tensor, num_samples):  # noqa: ANN001
+        captured["policy"] = tensor.clone()
+        return torch.tensor([0])
+
+    monkeypatch.setattr(torch, "multinomial", _fake_multinomial)
+
+    strategy = ModelAIStrategy(model, {"num_actions": 4}, torch.device("cpu"))
+    result = strategy.choose_action(object(), 0)
+
+    assert result == ("call", None)
+    # The illegal index (1) should be fully masked out despite having the largest raw advantage.
+    assert captured["policy"][1].item() == 0.0
+    assert torch.isclose(captured["policy"].sum(), torch.tensor(1.0))
+
+
+def test_model_ai_strategy_samples_uniform_when_no_positive_advantages(monkeypatch):
+    torch.manual_seed(0)
+    output = torch.tensor([-1.0, 5.0, 0.0, -0.2])
+    model = _make_model(4, output)
+
+    mask = torch.tensor([True, False, True, False], dtype=torch.bool)
+    captured = {}
+
+    monkeypatch.setattr(
+        "poker_ai.gui.playStrategy.get_legal_actions_mask",
+        lambda *_args, **_kwargs: mask,
+    )
+    monkeypatch.setattr(
+        "poker_ai.gui.playStrategy.get_action_from_index",
+        lambda idx, *_args, **_kwargs: {0: "check", 2: "raise"}[idx],
+    )
+    monkeypatch.setattr(
+        "poker_ai.gui.playStrategy.action_to_tuple",
+        lambda action: (action, None if action != "raise" else 25),
+    )
+
+    def _fake_multinomial(tensor, num_samples):  # noqa: ANN001
+        captured["policy"] = tensor.clone()
+        return torch.tensor([2])
+
+    monkeypatch.setattr(torch, "multinomial", _fake_multinomial)
+
+    strategy = ModelAIStrategy(model, {"num_actions": 4}, torch.device("cpu"))
+    result = strategy.choose_action(object(), 1)
+
+    assert result == ("raise", 25)
+    assert torch.allclose(captured["policy"], torch.tensor([0.5, 0.0, 0.5, 0.0]))
+
+
+def test_model_ai_strategy_fallback_behaviour(monkeypatch):
+    fallback_calls = []
+
+    class Fallback:
+        def choose_action(self, game, player_index):  # noqa: ANN001
+            fallback_calls.append((game, player_index))
+            return ("fold", None)
+
+    strategy = ModelAIStrategy(
+        model=None,
+        config={"num_actions": 2},
+        device=torch.device("cpu"),
+        fallback_strategy=Fallback(),
+    )
+
+    outcome = strategy.choose_action("game", 3)
+    assert outcome == ("fold", None)
+    assert fallback_calls == [("game", 3)]
+
+    # Simulate a misconfigured instance where neither a model nor fallback is available at runtime.
+    strategy.model = None
+    strategy._fallback_strategy = None
+    with pytest.raises(RuntimeError):
+        strategy.choose_action("game", 0)

--- a/tests/monitoring/test_torch_hooks.py
+++ b/tests/monitoring/test_torch_hooks.py
@@ -1,0 +1,60 @@
+import types
+
+import pytest
+import torch
+
+from poker_ai.monitoring import torch_hooks
+
+
+def test_attach_gradient_hooks_runs_backward_without_error():
+    if not torch_hooks._HAS_TORCH:  # pragma: no cover - safety for torch-less envs
+        pytest.skip("torch not available")
+
+    model = torch.nn.Linear(2, 1)
+    torch_hooks.attach_gradient_health_hooks(model)
+
+    x = torch.tensor([[1.0, 2.0]], requires_grad=False)
+    loss = model(x).sum()
+    loss.backward()
+
+
+def test_attach_gradient_hooks_detects_nan(monkeypatch):
+    if not torch_hooks._HAS_TORCH:  # pragma: no cover - safety for torch-less envs
+        pytest.skip("torch not available")
+
+    callbacks = []
+
+    class FakeParam:
+        requires_grad = True
+
+        def register_hook(self, fn):  # noqa: ANN001
+            callbacks.append(fn)
+            return types.SimpleNamespace(remove=lambda: None)
+
+    class FakeModel:
+        def named_parameters(self):  # noqa: ANN001
+            return [("weight", FakeParam())]
+
+    logged = []
+
+    class FakeLogger:
+        def log(self, name, value, extra=None):  # noqa: ANN001
+            logged.append((name, value, extra))
+
+    torch_hooks.attach_gradient_health_hooks(FakeModel(), logger=FakeLogger())
+
+    assert callbacks, "expected register_hook to be invoked"
+    with pytest.raises(FloatingPointError):
+        callbacks[0](torch.tensor(float("nan")))
+
+    assert logged == [("grad_nan_or_inf", 1.0, {"param": "weight"})]
+
+
+def test_attach_gradient_hooks_noop_without_torch(monkeypatch):
+    monkeypatch.setattr(torch_hooks, "_HAS_TORCH", False)
+
+    class SentinelModel:
+        def named_parameters(self):  # noqa: ANN001
+            raise AssertionError("should not be called when torch is missing")
+
+    torch_hooks.attach_gradient_health_hooks(SentinelModel())


### PR DESCRIPTION
## Summary
- add HumanStrategy tests covering optional analyzer display, invalid raise input handling, and non-raise actions
- add ModelAIStrategy regression tests covering legal action masking, fallback sampling, and fallback strategy behaviour
- add AI GTO analyzer tests for trainer caching, missing models, formatted output, and error logging
- verify attach_gradient_health_hooks handles finite gradients, NaNs, and torch-less environments

## Testing
- pytest tests/gui/test_human_strategy.py tests/gui/test_model_ai_strategy.py tests/evaluation/test_ai_gto_analyzer.py tests/monitoring/test_torch_hooks.py

------
https://chatgpt.com/codex/tasks/task_b_68da0546cff4832ab55e9f85a90ce59b