### PR TITLE
Fix self-play raise sizing to match engine expectations

### DIFF
--- a/src/poker_ai/selfplay/self_play.py
+++ b/src/poker_ai/selfplay/self_play.py
@@ -419,6 +419,12 @@ class SelfPlay:
 
         action = get_action_from_index(action_idx, game, player_id=player_id)
         action_str, amount = action_to_tuple(action)
+
+        if action_str == "raise" and amount is not None:
+            current_bet = getattr(getattr(game, "rules", game), "current_bet", 0)
+            if current_bet > 0:
+                amount = max(0, amount - current_bet)
+
         game.process_action(player_id, action_str, amount)
         game.rules.advance_turn()
 

--- a/tests/selfplay/test_raise_adjustment.py
+++ b/tests/selfplay/test_raise_adjustment.py
@@ -1,0 +1,32 @@
+from poker_ai.engine.texas_holdem import TexasHoldem
+from poker_ai.selfplay.self_play import SelfPlay
+from poker_ai.utils.action_mapping import get_action_from_index
+
+
+class _DummyTrainer:
+    def __init__(self):
+        self.config = {}
+
+
+def test_apply_action_uses_raise_increment():
+    trainer = _DummyTrainer()
+    sp = SelfPlay(trainer, {"num_players": 2, "starting_stack": 1000})
+
+    game = TexasHoldem(num_players=2, starting_stack=1000, verbose=False)
+    game.initialize_game()
+
+    current_player = game.rules.current_player
+    initial_bets = list(game.rules.bets)
+    action_index = 2  # first raise bucket beyond fold/call
+    action = get_action_from_index(action_index, game, player_id=current_player)
+    target_total = action.amount_to
+
+    assert target_total is not None and target_total > game.rules.current_bet
+
+    sp._apply_action_in_place(game, current_player, action_index)
+
+    assert game.rules.bets[current_player] == target_total
+    assert game.rules.current_bet == target_total
+    # ensure the opposing player's bet has not unintentionally changed
+    other_player = 1 - current_player
+    assert game.rules.bets[other_player] == initial_bets[other_player]


### PR DESCRIPTION
## Summary
- adjust self-play raise handling to send raise increments to the engine when raises or all-ins are selected
- add a regression test that verifies a sampled raise bucket results in the expected raise-to bet amount

## Testing
- pytest tests/selfplay/test_raise_adjustment.py
- pytest tests/selfplay tests/engine

------
https://chatgpt.com/codex/tasks/task_b_68da3f68eff0832aa10051e4ee05b045