### PR TITLE
Handle zero iteration weights in CFR trainers

### DIFF
--- a/src/poker_ai/ai/trainers/deep_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/deep_cfr_trainer.py
@@ -222,7 +222,13 @@ class DeepCFRTrainer:
         regrets = regrets - regrets.mean(dim=-1, keepdim=True)
 
         loss_vals = (adv_pred - regrets) ** 2
-        weighted_loss = (loss_vals * iterations).sum() / iterations.sum()
+
+        weights = iterations.clamp_min(0.0)
+        weight_sum = weights.sum()
+        if weight_sum.item() <= torch.finfo(loss_vals.dtype).eps:
+            weighted_loss = loss_vals.mean()
+        else:
+            weighted_loss = (loss_vals * weights).sum() / weight_sum
 
         self.optimizer.zero_grad(set_to_none=True)
         weighted_loss.backward()

--- a/src/poker_ai/ai/trainers/single_network_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/single_network_cfr_trainer.py
@@ -117,7 +117,13 @@ class SingleNetworkCFRTrainer:
 
         preds = self.model(holes, communities, histories)
         loss_vals = (preds - regrets) ** 2
-        weighted_loss = (loss_vals * iterations).sum() / iterations.sum()
+
+        weights = iterations.clamp_min(0.0)
+        weight_sum = weights.sum()
+        if weight_sum.item() <= torch.finfo(loss_vals.dtype).eps:
+            weighted_loss = loss_vals.mean()
+        else:
+            weighted_loss = (loss_vals * weights).sum() / weight_sum
 
         self.optimizer.zero_grad()
         weighted_loss.backward()

--- a/tests/test_trainer_weighted_loss.py
+++ b/tests/test_trainer_weighted_loss.py
@@ -1,0 +1,52 @@
+import math
+
+import torch
+
+from poker_ai.ai.trainers.deep_cfr_trainer import DeepCFRTrainer
+from poker_ai.ai.trainers.single_network_cfr_trainer import SingleNetworkCFRTrainer
+
+
+def _zeros_like(trainer):
+    hole = torch.zeros(trainer.card_feature_dim)
+    community = torch.zeros(trainer.card_feature_dim)
+    history = torch.zeros(1, trainer.history_feature_dim)
+    regrets = torch.tensor([1.0, -1.0])
+    return hole, community, history, regrets
+
+
+def test_single_network_training_handles_zero_iteration_weights():
+    torch.manual_seed(0)
+    trainer = SingleNetworkCFRTrainer(
+        input_feature_dim=4,
+        hidden_dim=8,
+        num_actions=2,
+        device="cpu",
+        buffer_capacity=8,
+    )
+
+    hole, community, history, regrets = _zeros_like(trainer)
+    for _ in range(4):
+        trainer.replay_buffer.push(hole, community, history, regrets, 0)
+
+    loss = trainer.train(batch_size=4)
+    assert math.isfinite(loss)
+    assert loss >= 0.0
+
+
+def test_deep_cfr_training_handles_zero_iteration_weights():
+    torch.manual_seed(0)
+    trainer = DeepCFRTrainer(
+        input_feature_dim=4,
+        hidden_dim=8,
+        num_actions=2,
+        device="cpu",
+        buffer_capacity=8,
+    )
+
+    hole, community, history, regrets = _zeros_like(trainer)
+    for _ in range(4):
+        trainer.replay_buffer.push(hole, community, history, regrets, 0)
+
+    loss = trainer.train(batch_size=4)
+    assert math.isfinite(loss)
+    assert loss >= 0.0


### PR DESCRIPTION
## Summary
- prevent division-by-zero in the DeepCFR and single-network CFR trainers by falling back to an unweighted mean loss when iteration weights sum to zero
- add targeted regression tests that cover zero-weight minibatches for both trainers

## Testing
- pytest tests/test_trainer_weighted_loss.py

------
https://chatgpt.com/codex/tasks/task_b_68da43b8a194832ab69d9035be1c0a00