### PR TITLE
Add centralized logging and diagnostics tooling

### DIFF
--- a/docs/logging_and_diagnostics.md
+++ b/docs/logging_and_diagnostics.md
@@ -1,0 +1,49 @@
+# Observability and Diagnostics
+
+This repository now ships with a centralized logging configuration and a small
+set of repeatable diagnostics that make it easier to reason about training
+runs.  The goal is to capture enough detail that a log file can be handed to an
+LLM for post-mortem analysis without additional context.
+
+## Centralized logging
+
+* The helper :func:`poker_ai.logging_utils.setup_logging` configures both
+  rotating file and console handlers.  By default logs are written under
+  ``logs/poker_ai.log`` with a timestamped, component-aware format.
+* ``setup_logging`` accepts the ``logging`` section from
+  ``config/config.yaml`` and automatically creates directories as needed.  Each
+  record contains the component name and run identifier so that multi-process
+  workflows remain distinguishable.
+* Call :func:`poker_ai.logging_utils.log_run_metadata` and
+  :func:`poker_ai.logging_utils.log_configuration_snapshot` at the start of a
+  run to capture environment details (Python/Torch versions, git commit, CLI
+  arguments, etc.) and the sanitized configuration that produced the run.
+* The training CLI, trainers, self-play loop, and evaluation utilities now emit
+  structured INFO-level messages whenever models are saved, training steps
+  complete, or significant events occur.  Rotating file handlers prevent logs
+  from growing without bound.
+
+## Quick diagnostics for algorithm validation
+
+Use the ``tools/run_diagnostics.py`` script to execute a set of fast checks that
+exercise the critical pieces of the CFR training pipeline:
+
+```bash
+python tools/run_diagnostics.py --algorithm ai_cfr --output diagnostics.json
+```
+
+The script performs the following actions (each recorded in the log and
+optionally in the emitted JSON report):
+
+1. **Forward pass check** – runs a single inference through the trainer's model
+   to ensure tensor shapes are consistent and logs the execution time.
+2. **Training step check** – performs a small gradient update to confirm that
+   the optimizer, loss computation, and gradients are wired correctly.
+3. **Optional self-play check** – include ``--include-self-play`` to execute a
+   lightweight MCCFR hand via ``SelfPlay``.  This takes longer but validates the
+   integration between the environment and the trainer.
+
+These diagnostics are light-weight enough to run before long training jobs or
+after code changes to validate algorithmic correctness and approximate
+efficiency.  Combine them with the detailed log files to quickly spot
+regressions or feed concise transcripts into an LLM for debugging assistance.

--- a/src/poker_ai/__init__.py
+++ b/src/poker_ai/__init__.py
@@ -1,0 +1,9 @@
+"""Poker AI package namespace."""
+
+from .logging_utils import (
+    log_configuration_snapshot,
+    log_run_metadata,
+    setup_logging,
+)
+
+__all__ = ["setup_logging", "log_run_metadata", "log_configuration_snapshot"]

--- a/src/poker_ai/ai/trainers/ai_cfr_trainer.py
+++ b/src/poker_ai/ai/trainers/ai_cfr_trainer.py
@@ -38,7 +38,7 @@ try:
     else:
         raise FileNotFoundError
 except Exception:
-    logging.warning(
+    logging.getLogger(__name__).warning(
         "config.yaml not found or PyYAML unavailable. Using default config values for AICFRTrainer.",
     )
     config = {
@@ -56,13 +56,6 @@ except Exception:
     }
 
 
-# Setup logging
-log_file_path = config["logging"]["log_file"]
-log_dir = os.path.dirname(log_file_path)
-if log_dir and not os.path.exists(log_dir):
-    os.makedirs(log_dir, exist_ok=True)
-logging.basicConfig(filename=log_file_path, level=logging.INFO, filemode="a")
-
 # Expose config for package-level access so tests can override it
 import sys
 
@@ -71,6 +64,7 @@ sys.modules[__package__ + ".config"] = config
 
 class AICFRTrainer:
     def __init__(self, device: str | None = None):
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         requested_device = (
             device if device is not None else ("cuda" if torch.cuda.is_available() else "cpu")
         )
@@ -95,6 +89,12 @@ class AICFRTrainer:
         else:
             self.device = requested_device
         self._using_xla = self._xla_device is not None
+        self.logger.debug(
+            "Initializing AICFRTrainer on device %s (using_xla=%s)",
+            self.device,
+            self._using_xla,
+            extra={"component": "trainer"},
+        )
         model_config = config.get("model", {})  # Get model sub-config, or empty dict
         hidden_dim = int(
             model_config.get("hidden_dim", AdvantageNetwork.DEFAULT_HIDDEN_DIM)
@@ -273,11 +273,15 @@ class AICFRTrainer:
             else:
                 self.optimizer.step()
 
-            logging.info(f"Training step completed. Loss: {loss.item()}")
+            self.logger.info(
+                "Training step completed | loss=%.6f",
+                float(loss.item()),
+                extra={"component": "trainer"},
+            )
             return float(loss.item())
 
         except Exception as e:  # pragma: no cover - logging path
-            logging.error(f"Error during training: {str(e)}", exc_info=True)
+            self.logger.exception("Error during training: %s", str(e))
             raise
 
     def _train_from_buffer(self, batch_size: int) -> float:
@@ -349,9 +353,13 @@ class AICFRTrainer:
                 self._xm.mark_step()
             else:
                 torch.save(payload, model_path)
-            logging.info(f"Model saved to {model_path}")
+            self.logger.info(
+                "Model saved | path=%s",
+                model_path,
+                extra={"component": "trainer"},
+            )
         except Exception as e:
-            logging.error(f"Error saving model: {str(e)}", exc_info=True)
+            self.logger.exception("Error saving model: %s", str(e))
 
     def load_model(self, model_path: str | None = None):
         # Ensure config path is correct or make it an argument
@@ -369,9 +377,13 @@ class AICFRTrainer:
             target_device = self._xla_device or self.device
             self.model.to(target_device)
             self.model.eval()
-            logging.info(f"Model loaded from {path}")
+            self.logger.info(
+                "Model loaded | path=%s",
+                path,
+                extra={"component": "trainer"},
+            )
         except Exception as e:
-            logging.error(f"Error loading model: {str(e)}", exc_info=True)
+            self.logger.exception("Error loading model: %s", str(e))
 
     def add_experience(
         self,
@@ -404,17 +416,19 @@ class AICFRTrainer:
         """Return the average strategy for a given information set."""
         cumulative_strategy = self.cumulative_strategy.get(info_set_id)
         if cumulative_strategy is None:
-            logging.warning(
+            self.logger.warning(
                 "Requested average strategy for unknown information set '%s'. Returning uniform.",
                 info_set_id,
+                extra={"component": "trainer"},
             )
             return torch.ones(self.num_actions, device=self.device) / self.num_actions
 
         sum_cumulative_strategy = torch.sum(cumulative_strategy)
         if sum_cumulative_strategy == 0:
-            logging.warning(
+            self.logger.warning(
                 "Cumulative strategy is all zeros for information set '%s'. Returning uniform strategy.",
                 info_set_id,
+                extra={"component": "trainer"},
             )
             return torch.ones(self.num_actions, device=self.device) / self.num_actions
         return cumulative_strategy / sum_cumulative_strategy

--- a/src/poker_ai/cli/train.py
+++ b/src/poker_ai/cli/train.py
@@ -3,8 +3,10 @@
 import argparse
 import glob
 import inspect
+import logging
 import os
 import time
+from datetime import datetime
 from typing import Any, cast
 
 import torch
@@ -13,6 +15,11 @@ from poker_ai.ai.models.transformer import AdvantageNetwork
 
 from poker_ai.config import load_config
 from poker_ai.evaluation.performance_analysis import ModelPerformanceAnalyzer
+from poker_ai.logging_utils import (
+    log_configuration_snapshot,
+    log_run_metadata,
+    setup_logging,
+)
 
 # Assuming the script is run from the project root,
 # and trainers, self_play, etc., are packages in that root.
@@ -129,6 +136,7 @@ def initialize_trainer(
         raise ValueError(f"Unknown algorithm: {algorithm}")
 
     if use_data_parallel:
+        logger = logging.getLogger(__name__)
         model_to_wrap = None
         if hasattr(trainer, "advantage_net"):
             model_to_wrap = trainer.advantage_net
@@ -136,14 +144,14 @@ def initialize_trainer(
             model_to_wrap = trainer.model
 
         if model_to_wrap:
-            print("Wrapping model with DataParallel for multi-device training.")
+            logger.info("Wrapping model with DataParallel for multi-device training.")
             wrapped_model = torch.nn.DataParallel(model_to_wrap)
             if hasattr(trainer, "advantage_net"):
                 trainer.advantage_net = wrapped_model
             elif hasattr(trainer, "model"):
                 trainer.model = wrapped_model
         else:
-            print("Warning: Could not find model to wrap for DataParallel.")
+            logger.warning("Could not find model to wrap for DataParallel.")
 
     return trainer
 
@@ -189,9 +197,12 @@ def _find_latest_model_path(config: dict, algorithm: str) -> str | None:
     return latest_path
 
 
-def _load_latest_model(trainer: object, config: dict, algorithm: str) -> bool:
+def _load_latest_model(
+    trainer: object, config: dict, algorithm: str, *, logger: logging.Logger | None = None
+) -> bool:
     """Attempt to load the latest saved model for the given trainer."""
 
+    logger = logger or logging.getLogger(__name__)
     load_attr = getattr(trainer, "load_model", None)
     if load_attr is None:
         return False
@@ -224,21 +235,19 @@ def _load_latest_model(trainer: object, config: dict, algorithm: str) -> bool:
                         training_section.pop("save_model_path", None)
                     else:
                         training_section["save_model_path"] = original_path
-        print(f"Loaded existing model from {latest_path}.")
+        logger.info("Loaded existing model from %s.", latest_path)
         return True
     except FileNotFoundError:
-        print(
+        logger.warning(
             "Latest model checkpoint was found in configuration but the file is missing. "
             "Starting from a fresh model."
         )
     except Exception as exc:  # pragma: no cover - defensive logging
-        print(f"Failed to load existing model from {latest_path}: {exc}")
+        logger.exception("Failed to load existing model from %s: %s", latest_path, exc)
     return False
 
 
 def main() -> None:  # noqa: C901
-    print("--- Starting Poker AI Training Session ---")
-
     args = parse_args()
     from unittest.mock import MagicMock
     for attr in (
@@ -255,15 +264,26 @@ def main() -> None:  # noqa: C901
         if isinstance(getattr(args, flag, None), MagicMock):
             setattr(args, flag, False)
 
-    device: str = "cpu"
-    use_data_parallel = False
-    device_printable = device
-
     if args.tpu and (args.gpus or args.npus):
         raise ValueError("Cannot specify --tpu with --gpus or --npus.")
 
     if args.gpus and args.npus:
         raise ValueError("Cannot specify both --gpus and --npus.")
+
+    config = load_configuration(args.config)
+    run_id = f"train-{datetime.utcnow().strftime('%Y%m%dT%H%M%S')}"
+    setup_logging(config.get("logging"), component="train_cli", run_id=run_id)
+    logger = logging.getLogger(__name__)
+
+    args_dict = {k: getattr(args, k) for k in vars(args)}
+    log_run_metadata(config=config, extra_context={"args": args_dict, "run_id": run_id})
+    log_configuration_snapshot(config, logger=logger)
+
+    logger.info("Starting Poker AI training session")
+
+    device: str = "cpu"
+    use_data_parallel = False
+    device_printable = device
 
     if args.tpu:
         try:
@@ -276,7 +296,7 @@ def main() -> None:  # noqa: C901
         xla_device = xm.xla_device()
         device = "xla"
         device_printable = f"{device} ({xla_device})"
-        print(f"TPU training enabled on device {xla_device}.")
+        logger.info("TPU training enabled on device %s", xla_device)
     elif args.npus:
         if hasattr(torch, "npu") and torch.npu.is_available():
             device = "npu"
@@ -284,13 +304,12 @@ def main() -> None:  # noqa: C901
             npu_count = torch.npu.device_count()
             if npu_count > 1:
                 use_data_parallel = True
-                print(f"Multi-NPU training enabled. Found {npu_count} NPUs.")
+                logger.info("Multi-NPU training enabled. Found %s NPUs.", npu_count)
             else:
-                print("NPU training enabled.")
+                logger.info("NPU training enabled.")
         else:
-            print(
-                "Warning: --npus specified, but no NPU devices are available. "
-                "Falling back to CPU."
+            logger.warning(
+                "--npus specified, but no NPU devices are available. Falling back to CPU."
             )
     elif args.gpus:
         if torch.cuda.is_available():
@@ -299,21 +318,19 @@ def main() -> None:  # noqa: C901
             gpu_count = torch.cuda.device_count()
             if gpu_count > 1:
                 use_data_parallel = True
-                print(f"Multi-GPU training enabled. Found {gpu_count} GPUs.")
+                logger.info("Multi-GPU training enabled. Found %s GPUs.", gpu_count)
             else:
-                print("GPU training enabled.")
+                logger.info("GPU training enabled.")
         else:
-            print(
-                "Warning: --gpus specified, but no GPU devices are available. "
-                "Falling back to CPU."
+            logger.warning(
+                "--gpus specified, but no GPU devices are available. Falling back to CPU."
             )
 
     analyzer_device = device if device != "xla" else "cpu"
     if device == "xla" and analyzer_device == "cpu":
-        print("ModelPerformanceAnalyzer evaluations will run on the CPU while training on TPU.")
-
-    # Load configuration
-    config = load_configuration(args.config)
+        logger.info(
+            "ModelPerformanceAnalyzer evaluations will run on the CPU while training on TPU."
+        )
 
     # Extract configurations with defaults
     # model_config is implicitly used by AICFRTrainer via its own global config load.
@@ -364,21 +381,20 @@ def main() -> None:  # noqa: C901
     big_blind = game_engine_config.get("big_blind", 10)
     small_blind = game_engine_config.get("small_blind", 5)
 
-    print("\n--- Configuration ---")
-    print(f"Total training iterations: {num_iterations}")
-    print(f"Save model every: {save_model_every_samples} iterations")
+    logger.info("Configuration summary: iterations=%s", num_iterations)
+    logger.info("Model snapshot interval (samples): %s", save_model_every_samples)
     if save_model_every_n_hands > 0:
-        print(f"Save model every {save_model_every_n_hands} hands")
+        logger.info("Model snapshot interval (hands): %s", save_model_every_n_hands)
     if save_model_every_minutes > 0:
-        print(f"Save model every {save_model_every_minutes} minutes")
-    print(f"Players per hand: random {min_players}-{max_players}")
-    print(f"Starting stack: {starting_stack}")
-    print(f"Blinds: SB={small_blind}, BB={big_blind}")
-    print(f"Using device: {device_printable}")
-    print(f"Min buffer before training: {min_buffer_before_train}")
+        logger.info("Model snapshot interval (minutes): %s", save_model_every_minutes)
+    logger.info("Players per hand: random %s-%s", min_players, max_players)
+    logger.info("Starting stack: %s", starting_stack)
+    logger.info("Blinds: SB=%s, BB=%s", small_blind, big_blind)
+    logger.info("Training device: %s", device_printable)
+    logger.info("Min buffer before training: %s", min_buffer_before_train)
 
     # Initialization
-    print("\n--- Initializing Components ---")
+    logger.info("Initializing components")
     game_config_for_selfplay = {
         "starting_stack": starting_stack,
         "big_blind": big_blind,
@@ -397,18 +413,15 @@ def main() -> None:  # noqa: C901
                 use_data_parallel=use_data_parallel,
             ),
         )
-        print(f"{args.algorithm} trainer initialized.")
+        logger.info("%s trainer initialized", args.algorithm)
     except Exception as e:
-        print(f"Error initializing trainer: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception("Error initializing trainer: %s", e)
         return
 
-    if _load_latest_model(cfr_trainer, config, args.algorithm):
-        print("Resumed training from the latest available checkpoint.")
+    if _load_latest_model(cfr_trainer, config, args.algorithm, logger=logger):
+        logger.info("Resumed training from the latest available checkpoint.")
     else:
-        print("No existing checkpoint found. Starting training from scratch.")
+        logger.info("No existing checkpoint found. Starting training from scratch.")
 
     # The new SelfPlay class for MCCFR doesn't need curriculum learning or complex setup.
     # It's simplified for the core algorithm.
@@ -419,7 +432,7 @@ def main() -> None:  # noqa: C901
     )
 
     # Training Loop
-    print("\n--- Starting Training Loop ---")
+    logger.info("Starting training loop")
     analyzer = ModelPerformanceAnalyzer(
         models_dir="models",
         save_every_iterations=save_model_every_samples,
@@ -431,7 +444,7 @@ def main() -> None:  # noqa: C901
     iteration = 0
     try:
         for iteration in range(1, num_iterations + 1):
-            print(f"\n--- MCCFR Iteration {iteration}/{num_iterations} ---")
+            logger.info("Starting MCCFR iteration %s/%s", iteration, num_iterations)
             # The play_hand_for_training method now runs one MCCFR traversal
             # and triggers the training step internally.
             self_play_env.play_hand_for_training(iteration)
@@ -441,7 +454,7 @@ def main() -> None:  # noqa: C901
                 path = f"models/{args.algorithm}_hand_{iteration}.pth"
                 os.makedirs(os.path.dirname(path), exist_ok=True)
                 cfr_trainer.save_model(path)
-                print(f"Model saved to {path} at iteration {iteration}")
+                logger.info("Model saved to %s at iteration %s", path, iteration)
 
             if (
                 save_model_every_minutes > 0
@@ -450,31 +463,29 @@ def main() -> None:  # noqa: C901
                 path = f"models/{args.algorithm}_time_{iteration}.pth"
                 os.makedirs(os.path.dirname(path), exist_ok=True)
                 cfr_trainer.save_model(path)
-                print(
-                    f"Model saved to {path} due to time interval at iteration {iteration}"
+                logger.info(
+                    "Model saved to %s due to time interval at iteration %s",
+                    path,
+                    iteration,
                 )
                 last_save_time = time.time()
 
             analyzer.on_iteration_end(cfr_trainer, iteration=iteration)
     except Exception as e:
-        import traceback
-
-        print(f"Error during iteration {iteration}: {e}")
-        traceback.print_exc()
+        logger.exception("Error during iteration %s: %s", iteration, e)
         raise
     else:
         # Final save after the loop
-        print("\n--- Training session finished ---")
-        print("Saving final model...")
+        logger.info("Training session finished. Saving final model...")
         final_model_path = f"models/{args.algorithm}_final.pth"
         os.makedirs(os.path.dirname(final_model_path), exist_ok=True)
         try:
             cfr_trainer.save_model(final_model_path)
-            print(f"Final model saved successfully to {final_model_path}")
+            logger.info("Final model saved successfully to %s", final_model_path)
         except Exception as e:
-            print(f"Error saving final model: {e}")
+            logger.exception("Error saving final model: %s", e)
 
-        print("\n--- Training Complete ---")
+        logger.info("Training complete")
 
 
 if __name__ == "__main__":

--- a/src/poker_ai/evaluation/performance_analysis.py
+++ b/src/poker_ai/evaluation/performance_analysis.py
@@ -1,6 +1,8 @@
 import glob
 import os
 
+import logging
+
 import torch
 
 from poker_ai.ai.models.transformer import AdvantageNetwork
@@ -172,6 +174,7 @@ class ModelPerformanceAnalyzer:
         self.tournament_size = tournament_size
         self.games_per_match = games_per_match
         self.device = device
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
     def on_iteration_end(self, trainer, iteration: int) -> None:
         if self.save_every_iterations is None:
@@ -181,7 +184,7 @@ class ModelPerformanceAnalyzer:
         os.makedirs(self.models_dir, exist_ok=True)
         path = os.path.join(self.models_dir, f"model_{iteration}.pth")
         trainer.save_model(path)
-        print(f"Model saved to {path} at iteration {iteration}")
+        self.logger.info("Model saved to %s at iteration %s", path, iteration)
         self._maybe_run_tournament()
 
     def _maybe_run_tournament(self) -> None:
@@ -189,7 +192,7 @@ class ModelPerformanceAnalyzer:
         if len(model_paths) < self.tournament_threshold:
             return
         selected = model_paths[-self.tournament_size :]
-        print("Running model tournament...")
+        self.logger.info("Running model tournament with %s candidates", len(selected))
         results = run_tournament(selected, self.games_per_match, self.device)
         for model, score in results.items():
-            print(f"{model}: {score}")
+            self.logger.info("Tournament result | model=%s | wins=%s", model, score)

--- a/src/poker_ai/logging_utils.py
+++ b/src/poker_ai/logging_utils.py
@@ -1,0 +1,248 @@
+"""Centralized logging utilities for Poker AI components.
+
+This module provides a consistent logging setup so that every entry point
+records rich, structured information that can be shared with an LLM when
+debugging.  The helpers here avoid each script configuring logging on its own
+and ensure that log files are created with contextual metadata such as the
+active component and run identifier.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import socket
+import sys
+from datetime import datetime
+from logging import Logger
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+DEFAULT_LOG_DIR = Path("logs")
+DEFAULT_LOG_FILENAME = "poker_ai.log"
+DEFAULT_FORMAT = (
+    "%(asctime)s | %(levelname)-8s | %(component)s | %(run_id)s | %(name)s | %(message)s"
+)
+DEFAULT_DATEFMT = "%Y-%m-%d %H:%M:%S"
+SENSITIVE_KEYS = {"password", "secret", "token", "key", "credential"}
+
+
+class _ContextFilter(logging.Filter):
+    """Inject component/run identifiers into all log records."""
+
+    def __init__(self, component: str | None, run_id: str | None) -> None:
+        super().__init__()
+        self._component = component or "core"
+        self._run_id = run_id or "session"
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple assignment
+        if not hasattr(record, "component"):
+            record.component = self._component
+        if not hasattr(record, "run_id"):
+            record.run_id = self._run_id
+        return True
+
+
+def _coerce_level(level: str | int | None) -> int:
+    if isinstance(level, int):
+        return level
+    if isinstance(level, str):
+        normalized = level.strip().upper()
+        if normalized.isdigit():
+            return int(normalized)
+        return getattr(logging, normalized, logging.INFO)
+    return logging.INFO
+
+
+def _resolve_log_path(
+    log_file: str | os.PathLike[str] | None, log_dir: str | os.PathLike[str] | None
+) -> Path:
+    if log_file:
+        path = Path(log_file).expanduser()
+        if not path.is_absolute():
+            # Respect user supplied directory but default to logs/ for plain filenames.
+            if not path.parent.name:
+                path = DEFAULT_LOG_DIR / path.name
+            else:
+                path = path
+    else:
+        target_dir = Path(log_dir).expanduser() if log_dir else DEFAULT_LOG_DIR
+        path = target_dir / DEFAULT_LOG_FILENAME
+    return path
+
+
+def setup_logging(
+    logging_config: Mapping[str, Any] | None = None,
+    *,
+    log_file: str | os.PathLike[str] | None = None,
+    level: str | int | None = None,
+    console: bool | None = None,
+    component: str | None = None,
+    run_id: str | None = None,
+    max_bytes: int = 10 * 1024 * 1024,
+    backup_count: int = 5,
+) -> Logger:
+    """Configure the root logger with rotating file/console handlers.
+
+    Parameters
+    ----------
+    logging_config:
+        Optional mapping taken from the configuration file.  Recognized keys are
+        ``level``, ``format``, ``datefmt``, ``log_file``, ``log_dir`` and
+        ``log_to_file``.
+    log_file:
+        Overrides the configured log file path.
+    level:
+        Desired logging level.  Accepts both integers and string levels.
+    console:
+        When ``True`` a ``StreamHandler`` is attached.  Defaults to ``True``.
+    component:
+        Logical name for the component emitting logs (e.g. ``"train_cli"``).
+    run_id:
+        Identifier included with each record to correlate multi-process runs.
+    max_bytes / backup_count:
+        Rotation parameters for the file handler.
+    """
+
+    config = dict(logging_config or {})
+    effective_level = _coerce_level(level or config.get("level"))
+    fmt = config.get("format", DEFAULT_FORMAT)
+    datefmt = config.get("datefmt", DEFAULT_DATEFMT)
+    log_to_file = bool(config.get("log_to_file", True))
+    if log_file is None:
+        log_file = config.get("log_file")
+    log_dir = config.get("log_dir")
+    target_path = _resolve_log_path(log_file, log_dir)
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(effective_level)
+
+    formatter = logging.Formatter(fmt=fmt, datefmt=datefmt)
+    context_filter = _ContextFilter(component, run_id)
+
+    if log_to_file or log_file:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            target_path, maxBytes=max_bytes, backupCount=backup_count
+        )
+        file_handler.setFormatter(formatter)
+        file_handler.addFilter(context_filter)
+        root.addHandler(file_handler)
+
+    if console is None:
+        console = True
+    if console:
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(formatter)
+        stream_handler.addFilter(context_filter)
+        root.addHandler(stream_handler)
+
+    logging.captureWarnings(True)
+    root.debug(
+        "Logging initialized at level %s with handlers: %s",
+        logging.getLevelName(effective_level),
+        ", ".join(type(handler).__name__ for handler in root.handlers),
+    )
+    return root
+
+
+def _sanitize_mapping(mapping: Mapping[str, Any]) -> Mapping[str, Any]:
+    sanitized: dict[str, Any] = {}
+    for key, value in mapping.items():
+        lowered = str(key).lower()
+        if any(sensitive in lowered for sensitive in SENSITIVE_KEYS):
+            sanitized[key] = "***"
+            continue
+        if isinstance(value, Mapping):
+            sanitized[key] = _sanitize_mapping(value)
+        elif isinstance(value, list):
+            sanitized[key] = [_sanitize_mapping(item) if isinstance(item, Mapping) else item for item in value]
+        else:
+            sanitized[key] = value
+    return sanitized
+
+
+def log_configuration_snapshot(
+    config: Mapping[str, Any] | None,
+    *,
+    logger: Logger | None = None,
+    redact: Iterable[str] | None = None,
+) -> None:
+    """Log the active configuration in JSON form for later inspection."""
+
+    if config is None:
+        return
+
+    logger = logger or logging.getLogger(__name__)
+    if redact:
+        redactions = set(redact)
+    else:
+        redactions = set()
+
+    prepared = dict(config)
+    for key in redactions:
+        if key in prepared:
+            prepared[key] = "***"
+    payload = _sanitize_mapping(prepared)
+    serialized = json.dumps(payload, indent=2, sort_keys=True)
+    logger.info("Configuration snapshot:%s%s", os.linesep, serialized)
+
+
+def _maybe_git_commit() -> str | None:
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:  # pragma: no cover - git not available on CI
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def log_run_metadata(
+    *, config: Mapping[str, Any] | None = None, extra_context: Mapping[str, Any] | None = None
+) -> None:
+    """Emit a structured record containing runtime and environment details."""
+
+    logger = logging.getLogger(__name__)
+    metadata: dict[str, Any] = {
+        "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "hostname": socket.gethostname(),
+        "cwd": str(Path.cwd()),
+    }
+    try:  # pragma: no cover - optional dependency
+        import torch
+
+        metadata["torch_version"] = torch.__version__
+        metadata["cuda_available"] = bool(getattr(torch, "cuda", None) and torch.cuda.is_available())
+    except Exception:
+        metadata["torch_version"] = "unavailable"
+    commit = _maybe_git_commit()
+    if commit:
+        metadata["git_commit"] = commit
+    if config is not None:
+        metadata["config_keys"] = sorted(config.keys())
+    if extra_context:
+        metadata["context"] = dict(extra_context)
+    logger.info("Run metadata: %s", json.dumps(metadata, sort_keys=True))
+
+
+__all__ = [
+    "DEFAULT_LOG_DIR",
+    "DEFAULT_LOG_FILENAME",
+    "setup_logging",
+    "log_run_metadata",
+    "log_configuration_snapshot",
+]

--- a/src/poker_ai/selfplay/self_play.py
+++ b/src/poker_ai/selfplay/self_play.py
@@ -43,6 +43,7 @@ class SelfPlay:
         game_engine_config: dict[str, Any],
         training_config: dict[str, Any] | None = None,
     ) -> None:
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.cfr_trainer = cfr_trainer
         self.starting_stack = game_engine_config.get("starting_stack", 1000)
         self.big_blind = game_engine_config.get("big_blind", 10)
@@ -61,6 +62,14 @@ class SelfPlay:
         self._last_loaded_model_path: Path | None = None
         self._last_loaded_model_mtime: float | None = None
         self._maybe_refresh_model(iteration=0, force=True)
+        self.logger.debug(
+            "Initialized SelfPlay | stack=%s | blinds=(%s,%s) | players=%s-%s",
+            self.starting_stack,
+            self.small_blind,
+            self.big_blind,
+            self.min_players,
+            self.max_players,
+        )
 
     def _determine_model_reload_interval(self, cfg: dict[str, Any]) -> int:
         """Return the frequency (in hands) for refreshing model weights."""
@@ -254,6 +263,9 @@ class SelfPlay:
         game.rules.big_blind = self.big_blind
         game.rules.small_blind = self.small_blind
         game.initialize_game()
+        self.logger.debug(
+            "Iteration %s | initialized game with %s players", iteration, num_players
+        )
 
         # 2. Perform a traversal for each player in the hand
         base_reach = [1.0] * num_players
@@ -264,10 +276,23 @@ class SelfPlay:
 
         # 3. After the traversals, run a training step on the collected data
 
-        if len(self.cfr_trainer.replay_buffer) >= self.min_buffer_before_train:
+        buffer_length = len(self.cfr_trainer.replay_buffer)
+        if buffer_length >= self.min_buffer_before_train:
             loss = self.cfr_trainer.train(batch_size=self.min_buffer_before_train)
             if loss is not None:
-                print(f"Iteration {iteration}: Training step complete. Loss: {loss:.4f}")
+                self.logger.info(
+                    "Iteration %s | training step complete | loss=%.6f | buffer=%s",
+                    iteration,
+                    float(loss),
+                    buffer_length,
+                )
+        else:
+            self.logger.debug(
+                "Iteration %s | buffer below threshold (%s/%s)",
+                iteration,
+                buffer_length,
+                self.min_buffer_before_train,
+            )
 
         return self.cfr_trainer.replay_buffer
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -48,7 +48,7 @@ def test_training_logs_loss(tmp_path):
         handler.close()
 
         contents = log_file.read_text()
-        assert "Training step completed. Loss:" in contents
+        assert "Training step completed | loss=" in contents
     finally:
         ai_cfr_trainer.config = original_config_pkg
         ai_cfr_trainer.ai_cfr_trainer_module.config = original_config_module

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,31 @@
+import logging
+
+from poker_ai.logging_utils import (
+    log_configuration_snapshot,
+    log_run_metadata,
+    setup_logging,
+)
+
+
+def test_setup_logging_writes_file(tmp_path):
+    log_path = tmp_path / "app.log"
+    setup_logging(
+        {"log_file": str(log_path), "level": "INFO", "log_to_file": True},
+        component="test",
+        run_id="unit",
+        console=False,
+    )
+    logger = logging.getLogger("testcase")
+    logger.info("hello world")
+    log_configuration_snapshot({"api": {"password": "secret", "timeout": 5}})
+    log_run_metadata(config={"foo": "bar"})
+
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+
+    contents = log_path.read_text()
+    assert "hello world" in contents
+    assert "***" in contents  # password redacted
+    assert "Run metadata" in contents
+
+    logging.shutdown()

--- a/tools/run_diagnostics.py
+++ b/tools/run_diagnostics.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Run quick algorithm diagnostics with detailed logging."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = _PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import torch
+
+from poker_ai.cli.train import initialize_trainer, load_configuration
+from poker_ai.logging_utils import log_configuration_snapshot, log_run_metadata, setup_logging
+from poker_ai.selfplay.self_play import SelfPlay
+
+
+def _diagnose_forward_pass(trainer: Any, logger: logging.Logger) -> dict[str, float]:
+    model = getattr(trainer, "model")
+    card_projection = getattr(model, "card_projection", None)
+    history_projection = getattr(model, "history_projection", None)
+    card_dim = getattr(card_projection, "in_features", 32)
+    history_dim = getattr(history_projection, "in_features", card_dim)
+    seq_len = getattr(model, "max_seq_len", None)
+    model_cfg = {}
+    if isinstance(getattr(trainer, "config", None), dict):
+        model_cfg = trainer.config.get("model", {})
+    seq_len = int(model_cfg.get("max_seq_len", seq_len or 16))
+    hole = torch.zeros(1, card_dim)
+    community = torch.zeros(1, card_dim)
+    history = torch.zeros(1, seq_len, history_dim)
+
+    start = time.perf_counter()
+    with torch.no_grad():
+        _ = trainer.model(hole, community, history)
+    duration = time.perf_counter() - start
+    logger.info("Forward pass succeeded | duration=%.4fs", duration)
+    return {"forward_pass_duration_s": duration}
+
+
+def _diagnose_training_step(trainer: Any, logger: logging.Logger) -> dict[str, float]:
+    model = getattr(trainer, "model")
+    card_projection = getattr(model, "card_projection", None)
+    history_projection = getattr(model, "history_projection", None)
+    card_dim = getattr(card_projection, "in_features", 32)
+    history_dim = getattr(history_projection, "in_features", card_dim)
+    model_cfg = {}
+    if isinstance(getattr(trainer, "config", None), dict):
+        model_cfg = trainer.config.get("model", {})
+    seq_len = int(model_cfg.get("max_seq_len", getattr(model, "max_seq_len", 16)))
+    legal_mask = torch.ones(trainer.num_actions, dtype=torch.bool)
+    hole = torch.zeros(card_dim)
+    community = torch.zeros(card_dim)
+    history = torch.zeros(seq_len, history_dim)
+    payoffs = torch.randn(trainer.num_actions)
+
+    start = time.perf_counter()
+    loss = trainer.train("diagnostic", hole, community, history, payoffs, mask=legal_mask)
+    duration = time.perf_counter() - start
+    loss_value = float(loss) if loss is not None else float("nan")
+    logger.info(
+        "Training step diagnostic | loss=%.6f | duration=%.4fs",
+        loss_value,
+        duration,
+    )
+    return {"training_step_loss": loss_value, "training_step_duration_s": duration}
+
+
+def _diagnose_self_play(trainer: Any, config: dict[str, Any], logger: logging.Logger) -> dict[str, float]:
+    game_cfg = {"starting_stack": 50, "big_blind": 1, "small_blind": 1, "min_players": 2, "max_players": 2}
+    training_cfg = dict(config.get("training", {}))
+    training_cfg["min_buffer_before_train"] = min(
+        int(training_cfg.get("min_buffer_before_train", 16)),
+        16,
+    )
+
+    env = SelfPlay(cfr_trainer=trainer, game_engine_config=game_cfg, training_config=training_cfg)
+    start = time.perf_counter()
+    buffer = env.play_hand_for_training(iteration=1)
+    duration = time.perf_counter() - start
+    size = len(buffer)
+    logger.info(
+        "Self-play diagnostic | entries=%s | duration=%.4fs | threshold=%s",
+        size,
+        duration,
+        env.min_buffer_before_train,
+    )
+    return {"self_play_duration_s": duration, "replay_buffer_size": size}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run quick diagnostics for Poker AI components")
+    parser.add_argument("--config", default=None, help="Path to configuration file")
+    parser.add_argument(
+        "--algorithm",
+        default="ai_cfr",
+        choices=["ai_cfr", "deep_cfr", "single_network"],
+        help="Trainer algorithm to initialize",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional path to write JSON diagnostics results",
+    )
+    parser.add_argument(
+        "--include-self-play",
+        action="store_true",
+        help="Run a lightweight self-play traversal (may take several seconds)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_configuration(args.config)
+    run_id = f"diagnostics-{datetime.utcnow().strftime('%Y%m%dT%H%M%S')}"
+    setup_logging(config.get("logging"), component="diagnostics", run_id=run_id)
+    logger = logging.getLogger("poker_ai.diagnostics")
+
+    log_run_metadata(config=config, extra_context={"command": "diagnostics", "run_id": run_id})
+    log_configuration_snapshot(config, logger=logger)
+    logging.getLogger("poker_ai.engine").setLevel(logging.WARNING)
+    logging.getLogger("poker_ai.engine.texas_holdem").setLevel(logging.WARNING)
+
+    try:
+        trainer = initialize_trainer(args.algorithm, config, device="cpu")
+    except Exception as exc:
+        logger.exception("Failed to initialize trainer: %s", exc)
+        return 1
+
+    results: dict[str, Any] = {"algorithm": args.algorithm, "run_id": run_id}
+
+    try:
+        results.update(_diagnose_forward_pass(trainer, logger))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception("Forward pass diagnostic failed: %s", exc)
+        results["forward_pass_error"] = str(exc)
+
+    try:
+        results.update(_diagnose_training_step(trainer, logger))
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.exception("Training step diagnostic failed: %s", exc)
+        results["training_step_error"] = str(exc)
+
+    if args.include_self_play:
+        try:
+            results.update(_diagnose_self_play(trainer, config, logger))
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.exception("Self-play diagnostic failed: %s", exc)
+            results["self_play_error"] = str(exc)
+    else:
+        logger.info("Skipping self-play diagnostic (enable with --include-self-play)")
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(results, indent=2, sort_keys=True))
+        logger.info("Wrote diagnostics report to %s", output_path)
+
+    logger.info("Diagnostics complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `poker_ai.logging_utils` with helpers to configure rotating file logging and capture runtime metadata
- refactor the training CLI, CFR trainer, self-play loop, and performance analyzer to use the shared logging facilities
- introduce a diagnostics script and documentation for quick health checks, plus unit tests covering the new logging pipeline

## Testing
- `pytest tests/test_logging_utils.py tests/test_logging.py`
- `python tools/run_diagnostics.py --algorithm ai_cfr --output /tmp/diag.json`


------
https://chatgpt.com/codex/tasks/task_b_68da7f16a31c832aa87e74d41ed97d17