### PR TITLE
Use timezone-aware UTC timestamps

### DIFF
--- a/src/poker_ai/cli/train.py
+++ b/src/poker_ai/cli/train.py
@@ -7,7 +7,7 @@ import logging
 import os
 import time
 import unittest.mock as mock
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, cast
 
 import torch
@@ -312,7 +312,7 @@ def main() -> None:  # noqa: C901
         raise ValueError("Cannot specify both --gpus and --npus.")
 
     config = load_configuration(args.config)
-    run_id = f"train-{datetime.utcnow().strftime('%Y%m%dT%H%M%S')}"
+    run_id = f"train-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}"
     setup_logging(config.get("logging"), component="train_cli", run_id=run_id)
     logger = logging.getLogger(__name__)
 

--- a/src/poker_ai/logging_utils.py
+++ b/src/poker_ai/logging_utils.py
@@ -17,7 +17,7 @@ import socket
 import sys
 import time
 import unittest.mock as mock
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import Logger
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -251,8 +251,12 @@ def log_run_metadata(
     """Emit a structured record containing runtime and environment details."""
 
     logger = logging.getLogger(__name__)
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    if timestamp.endswith("+00:00"):
+        timestamp = timestamp[:-6] + "Z"
+
     metadata: dict[str, Any] = {
-        "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "timestamp": timestamp,
         "python_version": sys.version.split()[0],
         "platform": platform.platform(),
         "hostname": socket.gethostname(),


### PR DESCRIPTION
## Summary
- replace use of deprecated `datetime.utcnow()` with timezone-aware UTC timestamps
- normalize run metadata timestamps to maintain trailing Z formatting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dfc23498cc832a844f4e6dfe600067