### PR TITLE
Add Colab performance notebook that loads Drive models

### DIFF
--- a/notebooks/performance_colab.ipynb
+++ b/notebooks/performance_colab.ipynb
@@ -1,0 +1,170 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Performance Evaluation (Colab)\n\n",
+    "This notebook evaluates saved poker agents by loading trained models from Google Drive and running a small round-robin tournament. It is optimized for execution in Google Colab."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n\n",
+    "The cells below prepare the environment, mount Google Drive (when running in Colab), and make the repository available on `sys.path`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n\n",
+    "try:\n",
+    "    import google.colab  # type: ignore[attr-defined]\n",
+    "    IN_COLAB = True\n",
+    "except Exception:  # pragma: no cover - best effort detection\n",
+    "    IN_COLAB = False\n\n",
+    "if IN_COLAB:\n",
+    "    REPO_ROOT = Path(\"/content/texas_holdem_ai_gatc\")\n",
+    "else:\n",
+    "    REPO_ROOT = Path.cwd()\n\n",
+    "if REPO_ROOT.exists():\n",
+    "    os.chdir(REPO_ROOT)\n",
+    "    repo_src = REPO_ROOT / \"src\"\n",
+    "    if repo_src.exists() and str(repo_src) not in sys.path:\n",
+    "        sys.path.insert(0, str(repo_src))\n",
+    "else:\n",
+    "    raise FileNotFoundError(f\"Expected repository at {REPO_ROOT}.\")\n\n",
+    "print(f\"Running in Colab: {IN_COLAB}\")\n",
+    "print(f\"Repository root: {REPO_ROOT}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "if IN_COLAB:\n",
+    "    from google.colab import drive\n\n",
+    "    drive.mount(\"/content/drive\", force_remount=False)\n",
+    "    print(\"Google Drive mounted.\")\n",
+    "else:\n",
+    "    print(\"Google Colab not detected; skipping Drive mount.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load models from Google Drive\n\n",
+    "Update `GOOGLE_DRIVE_MODELS_DIR` if your models live in a different folder. The code mirrors the models into the repository's `models/` directory so that the evaluation utilities can discover them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import shutil\n\n",
+    "GOOGLE_DRIVE_MODELS_DIR = Path(\"/content/drive/MyDrive/texas_holdem/models\")\n",
+    "LOCAL_MODELS_DIR = REPO_ROOT / \"models\"\n",
+    "LOCAL_MODELS_DIR.mkdir(parents=True, exist_ok=True)\n\n",
+    "if IN_COLAB and not GOOGLE_DRIVE_MODELS_DIR.exists():\n",
+    "    raise FileNotFoundError(\n",
+    "        \"Could not find models in Google Drive. Set GOOGLE_DRIVE_MODELS_DIR to the correct path.\"\n",
+    "    )\n\n",
+    "copied = []\n",
+    "for src in GOOGLE_DRIVE_MODELS_DIR.glob(\"*.pt\") if GOOGLE_DRIVE_MODELS_DIR.exists() else []:\n",
+    "    dst = LOCAL_MODELS_DIR / src.name\n",
+    "    if not dst.exists() or src.stat().st_mtime > dst.stat().st_mtime:\n",
+    "        shutil.copy2(src, dst)\n",
+    "        copied.append(dst.name)\n\n",
+    "if copied:\n",
+    "    print(\"Copied models:\")\n",
+    "    for name in copied:\n",
+    "        print(f\"  - {name}\")\n",
+    "else:\n",
+    "    available = list(LOCAL_MODELS_DIR.glob(\"*.pt\"))\n",
+    "    if available:\n",
+    "        print(\"Models already present locally. No copies needed.\")\n",
+    "    else:\n",
+    "        raise FileNotFoundError(\n",
+    "            \"No models found. Upload *.pt files to the Google Drive directory before running this cell.\"\n",
+    "        )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect available models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sorted_models = sorted(LOCAL_MODELS_DIR.glob(\"*.pt\"))\n",
+    "if not sorted_models:\n",
+    "    raise RuntimeError(\"No local models were discovered; make sure the previous step succeeded.\")\n\n",
+    "for path in sorted_models:\n",
+    "    size_mb = path.stat().st_size / (1024 * 1024)\n",
+    "    print(f\"{path.name}: {size_mb:.2f} MB\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run a tournament\n\n",
+    "Configure the number of games per match and select the device (`cpu` or `cuda`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from typing import Literal\n\n",
+    "import torch\n\n",
+    "from poker_ai.evaluation.performance_analysis import run_tournament\n\n",
+    "from pathlib import Path\n",
+    "\n",
+    "device: Literal[\"cpu\", \"cuda\"]\n",
+    "if torch.cuda.is_available():\n",
+    "    device = \"cuda\"\n",
+    "else:\n",
+    "    device = \"cpu\"\n\n",
+    "model_paths = [str(path) for path in sorted_models]\n",
+    "print(f\"Running evaluation on {len(model_paths)} models using device='{device}'.\")\n\n",
+    "results = run_tournament(model_paths, games_per_match=10, device=device)\n\n",
+    "print(\"\\nTournament results (wins per model):\")\n",
+    "for path, wins in sorted(results.items(), key=lambda item: item[1], reverse=True):\n",
+    "    print(f\"{Path(path).name}: {wins}\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Colab-friendly performance evaluation notebook that mounts Google Drive and mirrors saved models into the repo
- provide cells for inspecting discovered models and running the built-in round-robin tournament

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f0c682460c832ab8d9dc215d79520c