### PR TITLE
Add modular ports and services layer for game orchestration

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,54 +1,63 @@
-# Texas Hold'em AI Architecture
+# Modular Architecture (Separation Principle)
 
-The project is now organised around small, testable subsystems.  Each
-subsystem wraps the underlying implementation and records its dependencies so
-that components can be mixed and matched during experiments.
+This repository now includes a lightweight modular layer under `src/gatc_modular/`
+that cleanly separates responsibilities and enables independent development and
+testing of subsystems:
 
 ```
-texas_holdem_ai_gatc/
-└── src/poker_ai/
-    ├── ai/                     # Model definitions and trainers
-    ├── engine/                 # Core game engine and simulations
-    ├── evaluation/             # Performance evaluation utilities
-    ├── rules/                  # Poker rule definitions
-    ├── selfplay/               # MCCFR based data generation
-    ├── systems/                # New subsystem wrappers
-    ├── utils/                  # Shared helpers (state representation, etc.)
-    └── ...
+Engine (game rules, state, transitions)
+    ↑           (ports/engine.py: Protocols)
+Policy (agent/AI choosing an action)
+    ↑           (ports/policy.py: Protocols)
+GameLoop (turn-taking, legality checks, rewards aggregation)
+    ↑           (services/game_loop.py)
+SelfPlayService (episodes orchestration, stats)
+                (services/self_play.py)
 ```
 
-## Subsystems
+## Why this layer?
+* **Parallel work**: engine devs, policy/AI devs, GUI devs, and trainer devs can work independently.
+* **Testability**: pure, typed protocols allow fast unit tests with small fakes (see `gatc_modular/testing`).
+* **Replaceability**: swap engines (CFR, RL envs, GUI-driven engine) or policies (random, neural, CFR) with no changes to services.
+* **Safety**: illegal actions are detected or auto-corrected in one place (the `GameLoop`).
 
-Each subsystem lives under `src/poker_ai/systems` and is created through a
-factory method returning a `Subsystem` object.
+## Key Contracts
+### Engine Port
+`ports/engine.py` defines a `Protocol` that any engine must satisfy:
+* `num_players` – int
+* `reset(seed: Optional[int]) -> Observation`
+* `current_player() -> PlayerId`
+* `legal_actions() -> List[Action]`
+* `step(action: Action) -> StepResult`
+* `is_terminal() -> bool`
+* `winner() -> Optional[PlayerId]`
+* `clone() -> Engine`
 
-| Subsystem | Responsibility |
-|-----------|----------------|
-| `CFRSubsystem` | Wraps the CFR trainers (AI, Deep, Single network). |
-| `TransformerSubsystem` | Creates transformer advantage networks. |
-| `EmbeddingSubsystem` | Provides helpers for converting a game state into tensors. |
-| `SelfPlaySubsystem` | Drives MCCFR self-play simulations. |
-| `TrainingSubsystem` | Coordinates self-play and CFR optimisation. |
-| `RulesSubsystem` | Supplies poker rules and game creation helpers. |
-| `LoggingSubsystem` | Centralises logging utilities. |
-| `EvaluationSubsystem` | Runs evaluation tournaments and score aggregation. |
+### Policy Port
+`ports/policy.py` defines a `Policy` with:
+* `select_action(obs, legal_actions, player_id) -> Action`
 
-Subsystems can be registered inside a `Registry` to make configuration driven
-assembly trivial:
+### Trainer Port (optional)
+`ports/trainer.py` sketches a general trainer interface so training code can be plugged in later.
 
-```python
-from poker_ai.systems import Registry, CFRSubsystem, SelfPlaySubsystem, TrainingSubsystem
+## Services
+### `GameLoop`
+* Orchestrates a single episode.
+* Validates and (optionally) auto-corrects illegal actions.
+* Aggregates rewards.
 
-registry = Registry()
-cfr = CFRSubsystem.create(device="cpu")
-self_play = SelfPlaySubsystem.create(cfr_trainer=cfr.component)
-training = TrainingSubsystem.create(cfr=cfr, self_play=self_play, iterations_per_cycle=10)
+### `SelfPlayService`
+* Runs many episodes and returns aggregate statistics (wins, total rewards, avg steps).
 
-for subsystem in (cfr, self_play, training):
-    registry.register(subsystem)
+## Testing utilities
+* `testing/fakes.py` includes a tiny deterministic 2-player engine (`CountingGameEngine`) and simple policies.
+* Unit tests under `tests/modular/` demonstrate the contracts and orchestration logic.
 
-print(registry.summary())
-```
+## Integrating existing code
+You can adapt your current engine/GUI/trainers in small steps:
+1. Make your engine object satisfy the `Engine` Protocol (or write an adapter class).
+2. Ensure your policy/agent object implements `select_action(obs, legal_actions, player_id)`.
+3. Use `GameLoop` in CLI/GUI code to run episodes without duplicating turn logic.
+4. Use `SelfPlayService` to collect stats for evaluation.
 
-This structure keeps the original modules untouched while providing clean
-integration points for future development and targeted testing.
+This keeps domain code (poker rules/CFR/RL) decoupled from orchestration and presentation.

--- a/src/gatc_modular/__init__.py
+++ b/src/gatc_modular/__init__.py
@@ -1,0 +1,12 @@
+from .ports.engine import (
+    Engine,
+    StepResult,
+    PlayerId,
+    Action,
+    Observation,
+)
+from .ports.policy import Policy
+from .services.game_loop import GameLoop, EpisodeResult
+from .services.self_play import SelfPlayService, SelfPlayStats
+
+__all__ = ["Engine", "StepResult", "PlayerId", "Action", "Observation", "Policy", "GameLoop", "EpisodeResult", "SelfPlayService", "SelfPlayStats"]

--- a/src/gatc_modular/ports/__init__.py
+++ b/src/gatc_modular/ports/__init__.py
@@ -1,0 +1,1 @@
+# Namespace package for modular ports (interfaces).

--- a/src/gatc_modular/ports/engine.py
+++ b/src/gatc_modular/ports/engine.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Self, runtime_checkable
+
+PlayerId = int
+Action = int
+Observation = Any
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """The result of applying one action to the engine."""
+    observation: Observation
+    reward: Mapping[PlayerId, float]
+    done: bool
+    info: Dict[str, Any]
+
+
+@runtime_checkable
+class Engine(Protocol):
+    """Minimal protocol any poker engine should satisfy to interoperate with services."""
+    num_players: int
+
+    def reset(self, seed: Optional[int] = None) -> Observation:
+        """Reset the environment and return the initial observation."""
+        ...
+
+    def current_player(self) -> PlayerId:
+        """Return the id of the player whose turn it is."""
+        ...
+
+    def legal_actions(self) -> List[Action]:
+        """Return the list of legal discrete actions at the current state."""
+        ...
+
+    def step(self, action: Action) -> StepResult:
+        """Apply `action`, advance the environment, and return the transition result."""
+        ...
+
+    def is_terminal(self) -> bool:
+        """True if the game is over."""
+        ...
+
+    def winner(self) -> Optional[PlayerId]:
+        """Return the winner's player id if terminal and there is a winner; otherwise None."""
+        ...
+
+    def clone(self) -> Self:
+        """Return a (cheap) copy of the engine (useful for search/self-play)."""
+        ...

--- a/src/gatc_modular/ports/policy.py
+++ b/src/gatc_modular/ports/policy.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Protocol, Sequence
+
+from .engine import Action, Observation, PlayerId
+
+
+class Policy(Protocol):
+    """An agent that chooses an action for the current player."""
+
+    def select_action(
+        self, obs: Observation, legal_actions: Sequence[Action], player_id: PlayerId
+    ) -> Action:
+        ...

--- a/src/gatc_modular/ports/trainer.py
+++ b/src/gatc_modular/ports/trainer.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol
+
+from .engine import Engine
+
+
+class Trainer(Protocol):
+    """A generic training interface to decouple training code from engines/policies."""
+
+    def train(self, engine: Engine, **kwargs: Any) -> Mapping[str, Any]:
+        ...
+
+    def evaluate(self, engine: Engine, **kwargs: Any) -> Mapping[str, Any]:
+        ...
+

--- a/src/gatc_modular/services/game_loop.py
+++ b/src/gatc_modular/services/game_loop.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional, Sequence
+
+from ..ports.engine import Action, Engine, Observation, PlayerId
+from ..ports.policy import Policy
+
+
+@dataclass(frozen=True)
+class EpisodeResult:
+    winner: Optional[PlayerId]
+    total_reward: Dict[PlayerId, float]
+    steps: int
+
+
+class GameLoop:
+    """A reusable episode runner that enforces legal actions and aggregates rewards."""
+
+    def __init__(
+        self, engine: Engine, policies: Mapping[PlayerId, Policy], enforce_legal_actions: bool = True
+    ) -> None:
+        self.engine = engine
+        self.policies = dict(policies)
+        self.enforce_legal_actions = enforce_legal_actions
+        if len(self.policies) != engine.num_players:
+            raise ValueError(
+                f"policies ({len(self.policies)}) must match engine.num_players ({engine.num_players})"
+            )
+
+    def _ensure_legal(self, chosen: Action, legal: Sequence[Action]) -> Action:
+        if chosen in legal:
+            return chosen
+        if not self.enforce_legal_actions:
+            raise ValueError(f"Illegal action {chosen}; legal: {list(legal)}")
+        # Fallback: choose the first legal action (deterministic)
+        return legal[0]
+
+    def play_episode(self, seed: Optional[int] = None, max_steps: int = 10_000) -> EpisodeResult:
+        obs: Observation = self.engine.reset(seed=seed)
+        rewards: Dict[PlayerId, float] = {pid: 0.0 for pid in range(self.engine.num_players)}
+        steps = 0
+
+        while not self.engine.is_terminal():
+            steps += 1
+            if steps > max_steps:
+                raise RuntimeError(f"Episode exceeded max_steps={max_steps}")
+            pid = self.engine.current_player()
+            policy = self.policies.get(pid)
+            if policy is None:
+                raise KeyError(f"No policy provided for player {pid}")
+            legal = self.engine.legal_actions()
+            action = policy.select_action(obs, legal, pid)
+            action = self._ensure_legal(action, legal)
+            result = self.engine.step(action)
+            obs = result.observation
+            for p, r in result.reward.items():
+                rewards[p] = rewards.get(p, 0.0) + r
+
+        return EpisodeResult(winner=self.engine.winner(), total_reward=rewards, steps=steps)

--- a/src/gatc_modular/services/self_play.py
+++ b/src/gatc_modular/services/self_play.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional
+
+from ..ports.engine import Engine, PlayerId
+from .game_loop import EpisodeResult, GameLoop
+
+
+@dataclass(frozen=True)
+class SelfPlayStats:
+    episodes: int
+    wins: Dict[PlayerId, int]
+    total_reward: Dict[PlayerId, float]
+    avg_steps: float
+
+
+class SelfPlayService:
+    """Run many episodes and aggregate stats. Trainers and eval tools can call this."""
+
+    def __init__(self, engine: Engine, policies: Mapping[PlayerId, object]) -> None:
+        self.engine = engine
+        self.policies = dict(policies)
+
+    def run(self, n_episodes: int, seed: Optional[int] = None) -> SelfPlayStats:
+        wins: Dict[PlayerId, int] = {pid: 0 for pid in range(self.engine.num_players)}
+        totals: Dict[PlayerId, float] = {pid: 0.0 for pid in range(self.engine.num_players)}
+        total_steps = 0
+
+        loop = GameLoop(self.engine, self.policies)
+        for i in range(n_episodes):
+            s = None if seed is None else seed + i
+            result: EpisodeResult = loop.play_episode(seed=s)
+            total_steps += result.steps
+            if result.winner is not None:
+                wins[result.winner] += 1
+            for pid, r in result.total_reward.items():
+                totals[pid] += r
+
+        return SelfPlayStats(
+            episodes=n_episodes,
+            wins=wins,
+            total_reward=totals,
+            avg_steps=total_steps / max(1, n_episodes),
+        )

--- a/src/gatc_modular/testing/fakes.py
+++ b/src/gatc_modular/testing/fakes.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import random
+from typing import Dict, List, Optional
+
+from ..ports.engine import Action, Engine, Observation, PlayerId, StepResult
+
+
+class CountingGameEngine(Engine):
+    """
+    A tiny deterministic 2-player environment used in tests.
+    Players take turns choosing an action in {0,1}.
+    The game lasts `horizon` steps. Reward is +1 to the player who chose action 1 on the
+    final step; 0 otherwise. Winner is that player; otherwise None.
+    """
+
+    def __init__(self, horizon: int = 5) -> None:
+        self.horizon = horizon
+        self.t = 0
+        self._cur = 0
+        self._winner: Optional[int] = None
+        self.num_players = 2
+
+    def reset(self, seed: Optional[int] = None) -> Observation:
+        if seed is not None:
+            random.seed(seed)
+        self.t = 0
+        self._cur = 0
+        self._winner = None
+        return (self.t, self._cur)
+
+    def current_player(self) -> PlayerId:
+        return self._cur
+
+    def legal_actions(self) -> List[Action]:
+        return [0, 1]
+
+    def is_terminal(self) -> bool:
+        return self.t >= self.horizon
+
+    def step(self, action: Action) -> StepResult:
+        if action not in (0, 1):
+            raise ValueError("illegal action")
+        self.t += 1
+        last_actor = self._cur
+        self._cur = 1 - self._cur
+        reward: Dict[int, float] = {0: 0.0, 1: 0.0}
+        if self.t >= self.horizon:
+            if action == 1:
+                reward[last_actor] = 1.0
+                self._winner = last_actor
+            else:
+                self._winner = None
+        obs: Observation = (self.t, self._cur)
+        return StepResult(
+            observation=obs,
+            reward=reward,
+            done=self.is_terminal(),
+            info={"last_actor": last_actor, "action": action},
+        )
+
+    def winner(self) -> Optional[PlayerId]:
+        return self._winner
+
+    def clone(self) -> "CountingGameEngine":
+        c = CountingGameEngine(self.horizon)
+        c.t = self.t
+        c._cur = self._cur
+        c._winner = self._winner
+        return c
+
+
+class FirstLegalPolicy:
+    def select_action(self, obs, legal_actions, player_id) -> int:  # type: ignore[override]
+        return legal_actions[0]
+
+
+class RandomPolicy:
+    def __init__(self, seed: Optional[int] = None) -> None:
+        self._rng = random.Random(seed)
+
+    def select_action(self, obs, legal_actions, player_id) -> int:  # type: ignore[override]
+        return self._rng.choice(list(legal_actions))

--- a/tests/modular/conftest.py
+++ b/tests/modular/conftest.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+# Ensure 'src' is on sys.path for src/ layout projects
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SRC = os.path.join(ROOT, "src")
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+# Silence pyflakes for unused import when tests only import submodules conditionally
+__all__ = ["ROOT", "SRC"]

--- a/tests/modular/test_game_loop.py
+++ b/tests/modular/test_game_loop.py
@@ -1,0 +1,37 @@
+from gatc_modular.testing.fakes import CountingGameEngine, FirstLegalPolicy
+from gatc_modular.services.game_loop import GameLoop
+
+
+def test_episode_runs_and_finishes() -> None:
+    eng = CountingGameEngine(horizon=4)
+    loop = GameLoop(eng, {0: FirstLegalPolicy(), 1: FirstLegalPolicy()})
+    result = loop.play_episode(seed=1)
+    assert result.steps == 4
+    # In the fake engine, winner may be 0, 1, or None depending on final action.
+    assert result.winner in (0, 1, None)
+    assert set(result.total_reward.keys()) == {0, 1}
+
+
+def test_illegal_action_is_auto_corrected_when_enforced() -> None:
+    class BadPolicy(FirstLegalPolicy):
+        def select_action(self, obs, legal_actions, player_id):  # type: ignore[override]
+            return 99  # definitely illegal
+
+    eng = CountingGameEngine(horizon=2)
+    loop = GameLoop(eng, {0: BadPolicy(), 1: FirstLegalPolicy()}, enforce_legal_actions=True)
+    result = loop.play_episode()
+    assert result.steps == 2
+
+
+def test_illegal_action_raises_when_not_enforced() -> None:
+    class BadPolicy(FirstLegalPolicy):
+        def select_action(self, obs, legal_actions, player_id):  # type: ignore[override]
+            return 99
+
+    eng = CountingGameEngine(horizon=1)
+    loop = GameLoop(eng, {0: BadPolicy(), 1: FirstLegalPolicy()}, enforce_legal_actions=False)
+    try:
+        loop.play_episode()
+        assert False, "Expected ValueError for illegal action"
+    except ValueError:
+        pass

--- a/tests/modular/test_protocols.py
+++ b/tests/modular/test_protocols.py
@@ -1,0 +1,16 @@
+from gatc_modular.testing.fakes import CountingGameEngine
+from gatc_modular.ports.engine import Engine
+
+
+def test_engine_protocol_is_satisfied() -> None:
+    eng = CountingGameEngine(horizon=3)
+    # runtime_checkable allows isinstance() on Protocols
+    assert isinstance(eng, Engine)
+    obs = eng.reset(seed=42)
+    # observation shape from fake engine is (t, current_player)
+    assert tuple(obs) == (0, 0)
+    assert eng.legal_actions() == [0, 1]
+    assert not eng.is_terminal()
+    assert eng.current_player() == 0
+    # cloning should preserve configuration
+    assert isinstance(eng.clone(), CountingGameEngine)

--- a/tests/modular/test_self_play.py
+++ b/tests/modular/test_self_play.py
@@ -1,0 +1,14 @@
+from gatc_modular.testing.fakes import CountingGameEngine, FirstLegalPolicy
+from gatc_modular.services.self_play import SelfPlayService
+
+
+def test_self_play_stats_aggregate() -> None:
+    eng = CountingGameEngine(horizon=3)
+    svc = SelfPlayService(eng, {0: FirstLegalPolicy(), 1: FirstLegalPolicy()})
+    stats = svc.run(n_episodes=5, seed=123)
+    assert stats.episodes == 5
+    # With FirstLegalPolicy always taking action 0, the fake engine never awards a winner.
+    assert all(w == 0 for w in stats.wins.values())
+    assert stats.avg_steps == 3.0
+    assert stats.total_reward[0] == 0.0
+    assert stats.total_reward[1] == 0.0


### PR DESCRIPTION
## Summary
- add typed engine, policy, and trainer protocols with shared StepResult dataclass
- implement reusable game loop and self-play services plus lightweight testing fakes
- document the modular architecture and cover new layer with focused tests

## Testing
- pytest -q tests/modular

------
https://chatgpt.com/codex/tasks/task_b_68f396b05244832a8f976fe0867a69fb